### PR TITLE
Replace deprecated Cloudflare pages-action with wrangler-action

### DIFF
--- a/.github/workflows/deploy-production.yaml
+++ b/.github/workflows/deploy-production.yaml
@@ -16,7 +16,6 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      deployments: write
     name: Deploy to Cloudflare Pages
     steps:
       - name: Checkout
@@ -47,10 +46,8 @@ jobs:
 
       - name: Publish
         if: github.event_name != 'pull_request'
-        uses: cloudflare/pages-action@1
+        uses: cloudflare/wrangler-action@9acf94ace14e7dc412b076f2c5c20b8ce93c79cd # v3
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-          projectName: app-store-production
-          directory: public
-          gitHubToken: ${{ secrets.GITHUB_TOKEN }}
+          command: pages deploy public --project-name=app-store-production --branch=${{ github.ref_name }}

--- a/.github/workflows/deploy-stage.yaml
+++ b/.github/workflows/deploy-stage.yaml
@@ -16,7 +16,6 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      deployments: write
     name: Deploy to Cloudflare Pages
     steps:
       - name: Checkout
@@ -47,10 +46,8 @@ jobs:
 
       - name: Publish
         if: github.event_name != 'pull_request'
-        uses: cloudflare/pages-action@1
+        uses: cloudflare/wrangler-action@9acf94ace14e7dc412b076f2c5c20b8ce93c79cd # v3
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-          projectName: "app-store-stage"
-          directory: public
-          gitHubToken: ${{ secrets.GITHUB_TOKEN }}
+          command: pages deploy public --project-name=app-store-stage --branch=${{ github.ref_name }}


### PR DESCRIPTION
`cloudflare/pages-action@1` is deprecated and was being force-run on Node 24 (it targets the retired Node 20). This switches both deploy workflows to the supported **`cloudflare/wrangler-action`** running `wrangler pages deploy`.

- **Pinned to a commit SHA** (`9acf94a…`, = `v3`) rather than a floating tag.
- Deploys the triggering branch via `--branch=${{ github.ref_name }}` so `master → app-store-stage` and `production → app-store-production` behave as before.
- Same secrets (`CLOUDFLARE_API_TOKEN`, `CLOUDFLARE_ACCOUNT_ID`) and output dir (`public`).
- Dropped the now-unneeded `deployments: write` permission (least privilege).

Validation: merging this to `master` will exercise the new stage deploy for real (the previous deploy via the old action published 62 files to https://app-store-stage.pages.dev). Production is unchanged in mechanism and will be exercised on the next `production` push.

🤖 Generated with [Claude Code](https://claude.com/claude-code)