### PR TITLE
Update LinkedIn link to company page

### DIFF
--- a/hugo.toml
+++ b/hugo.toml
@@ -24,7 +24,7 @@ disableKinds = ["taxonomy", "term", "rss", "section"]
   [params.social]
     facebook = "https://www.facebook.com/Screenly/"
     twitter = "https://twitter.com/ScreenlyApp"
-    linkedin = "https://www.linkedin.com/company-beta/10478856/"
+    linkedin = "https://www.linkedin.com/company/screenly-inc/"
     github = "https://github.com/orgs/Screenly/"
     medium = "https://news.screenly.io/"
 


### PR DESCRIPTION
Updates the LinkedIn social link in `hugo.toml` from the legacy `company-beta/10478856/` URL to the canonical company page `https://www.linkedin.com/company/screenly-inc/`.

The footer, header, and SEO partials all reference this single param, so they pick up the change automatically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)