### PR TITLE
Promote master to production: signage-apps.com rebrand

### DIFF
--- a/.github/workflows/deploy-production.yaml
+++ b/.github/workflows/deploy-production.yaml
@@ -42,7 +42,7 @@ jobs:
         run: bun test
 
       - name: Build
-        run: hugo --gc --minify --baseURL "https://app-store.srly.io/"
+        run: hugo --gc --minify --baseURL "https://signage-apps.com/"
 
       - name: Publish
         if: github.event_name != 'pull_request'

--- a/.github/workflows/deploy-stage.yaml
+++ b/.github/workflows/deploy-stage.yaml
@@ -42,7 +42,7 @@ jobs:
         run: bun test
 
       - name: Build
-        run: hugo --gc --minify --baseURL "https://stage-app-store.srly.io/"
+        run: hugo --gc --minify --environment staging --baseURL "https://stage.signage-apps.com/"
 
       - name: Publish
         if: github.event_name != 'pull_request'

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Screenly App Store
 
-Screenly Apps for digital signage — a static site built with
+Digital signage apps, a static site built with
 [Hugo](https://gohugo.io/) (extended) and [Bun](https://bun.sh/) for JavaScript
 dependency management, linting and tests.
 
@@ -38,14 +38,14 @@ The site is then available at http://127.0.0.1:8080
 * **Styles** use [Tailwind CSS v4](https://tailwindcss.com/) (`assets/css/app.css`),
   compiled by Hugo via PostCSS and fingerprinted. Design tokens live in the
   `@theme` block; reusable patterns in `@layer components`.
-* **JavaScript** is plain modern ESM in `assets/js/` — no jQuery. The only
+* **JavaScript** is plain modern ESM in `assets/js/`, no jQuery. The only
   third-party libraries (clipboard.js, Sentry) are installed via Bun and bundled
   locally by Hugo's esbuild; nothing is loaded from a CDN. Pure logic is unit
   tested with `bun test`.
 * **Images** are processed through Hugo's image pipeline (responsive WebP,
   `srcset`, lazy-loading, intrinsic dimensions).
 * **Fonts** (Space Grotesk, Space Mono, Open Sans) are self-hosted from the
-  Bun-managed `@fontsource/*` packages — no remote font requests.
+  Bun-managed `@fontsource/*` packages, no remote font requests.
 
 ## Deployment
 

--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -5,7 +5,7 @@
 @source "../../content";
 
 /* ----------------------------------------------------------------------------
-   Design tokens — "Video Wall" system (exposed as Tailwind theme + CSS vars)
+   Design tokens: "Video Wall" system (exposed as Tailwind theme + CSS vars)
 ---------------------------------------------------------------------------- */
 @theme {
   --color-bg: #0c0a14;        /* page canvas (near-black indigo) */
@@ -128,7 +128,7 @@
   .brand__name { @apply font-display text-lg font-bold leading-none; }
   .brand__sub { @apply text-dim font-normal; }
 
-  /* App "screen" card — the signature element */
+  /* App "screen" card: the signature element */
   .card-screen {
     @apply block overflow-hidden rounded-2xl border border-line bg-surface transition-all duration-300;
   }

--- a/assets/js/config.js
+++ b/assets/js/config.js
@@ -1,7 +1,7 @@
 /* global google */
 // App configuration page (Weather / Clock): builds the launch URL from the
 // chosen options and an optional map location. The Google Maps API is loaded
-// on demand — it is an external service with no local equivalent.
+// on demand. It is an external service with no local equivalent.
 import { buildQueryUrl } from './lib/query-url.js';
 
 const GOOGLE_MAPS_API_KEY = 'AIzaSyD4xizgVnzfyTQgM15V3tvihZxQDAdUuAg';

--- a/assets/js/lib/query-url.js
+++ b/assets/js/lib/query-url.js
@@ -1,5 +1,5 @@
 // Build an app launch URL from a base URL plus a map of query parameters,
-// skipping any empty values. Pure function — unit tested with `bun test`.
+// skipping any empty values. Pure function, unit tested with `bun test`.
 export function buildQueryUrl(url, params) {
   const query = Object.entries(params)
     .filter(([, value]) => value)

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -1,5 +1,5 @@
 // Site-wide entry point. Bundled locally by Hugo's esbuild (js.Build) from the
-// Bun-managed dependencies — no remote script loading, no jQuery.
+// Bun-managed dependencies, no remote script loading, no jQuery.
 import './sentry.js';
 import { initAppGrid, initModals, initScrollClasses } from './ui.js';
 import { initClipboard } from './clipboard.js';

--- a/content/capitals/index.html
+++ b/content/capitals/index.html
@@ -1,6 +1,6 @@
 ---
 title: Capital Quiz
-description: "A full-screen capital-city quiz — one country per load: name the capital, then see it revealed with its city and country population."
+description: "A full-screen capital-city quiz, one country per load: name the capital, then see it revealed with its city and country population."
 cardtext: Name the capital, on any display.
 masonry: Quiz
 bodyclass: product

--- a/content/quotes/index.html
+++ b/content/quotes/index.html
@@ -1,6 +1,6 @@
 ---
 title: Quotes
-description: A full-screen quotation for any display — one work-friendly quote, chosen at random on each load.
+description: A full-screen quotation for any display, one work-friendly quote, chosen at random on each load.
 cardtext: A fresh quote for any display.
 masonry: Quotes
 bodyclass: product

--- a/content/word/index.html
+++ b/content/word/index.html
@@ -1,6 +1,6 @@
 ---
 title: Word of the Day
-description: A full-screen word of the day — one word, its pronunciation, and its meaning, chosen fresh each day.
+description: A full-screen word of the day: one word, its pronunciation, and its meaning, chosen fresh each day.
 cardtext: A new word every day, on any display.
 masonry: Words
 bodyclass: product

--- a/content/word/index.html
+++ b/content/word/index.html
@@ -1,6 +1,6 @@
 ---
 title: Word of the Day
-description: A full-screen word of the day: one word, its pronunciation, and its meaning, chosen fresh each day.
+description: A full-screen word of the day, one word, its pronunciation, and its meaning, chosen fresh each day.
 cardtext: A new word every day, on any display.
 masonry: Words
 bodyclass: product

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,6 +3,6 @@
 services:
   web:
     build: .
-    image: app_store_srly_io:latest
+    image: signage_apps_com:latest
     ports:
       - "8080:80"

--- a/hugo.toml
+++ b/hugo.toml
@@ -1,10 +1,10 @@
-baseURL = "https://app-store.srly.io/"
+baseURL = "https://signage-apps.com/"
 languageCode = "en-us"
 title = "Free Digital Signage Apps"
 enableRobotsTXT = true
 enableGitInfo = true
 
-# No blog/taxonomies/section listings on this site — keep the output minimal.
+# No blog/taxonomies/section listings on this site. Keep the output minimal.
 disableKinds = ["taxonomy", "term", "rss", "section"]
 
 # Populate <lastmod> in Hugo's generated sitemap: prefer the git commit date,

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -9,7 +9,7 @@
             </h1>
             <p class="mt-6 max-w-xl text-lg text-dim">
                 <strong class="font-semibold text-ink">Free</strong>, vendor-agnostic digital signage
-                apps. Pick one, copy the link, and run it on any smart TV or signage player —
+                apps. Pick one, copy the link, and run it on any smart TV or signage player:
                 free and open-source with <strong class="font-semibold text-ink">Anthias</strong>, or
                 fully managed with <strong class="font-semibold text-ink">Screenly</strong>.
             </p>

--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -3,7 +3,7 @@
             <div class="text-center">
                 <p class="eyebrow">Run it your way</p>
                 <h2 class="mt-4 text-3xl sm:text-5xl">Free and open, or fully managed.</h2>
-                <p class="mx-auto mt-4 max-w-xl text-dim">Every one of these apps runs on both. Pick the platform that fits — there's no vendor lock-in.</p>
+                <p class="mx-auto mt-4 max-w-xl text-dim">Every one of these apps runs on both. Pick the platform that fits. There's no vendor lock-in.</p>
             </div>
 
             <div class="mx-auto mt-10 grid max-w-3xl gap-5 sm:grid-cols-2">
@@ -27,7 +27,7 @@
                 <div>
                     <a class="brand" href="{{ "/" | relURL }}">
                         {{ partial "optimg.html" (dict "src" "img/logo-light.png" "alt" "Screenly" "widths" (slice 72 144) "sizes" "36px" "class" "brand__mark") }}
-                        <span class="brand__name">Screenly <span class="brand__sub">Apps</span></span>
+                        <span class="brand__name">Digital Signage <span class="brand__sub">Apps</span></span>
                     </a>
                     <p class="mt-4 max-w-sm text-sm text-faint">Free, vendor-agnostic digital signage apps for every smart TV and signage player.</p>
                 </div>

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -4,7 +4,7 @@
     <div class="wrap flex h-16 items-center justify-between gap-4">
         <a class="brand" href="{{ "/" | relURL }}">
             {{ partial "optimg.html" (dict "src" "img/logo-light.png" "alt" "Screenly" "widths" (slice 72 144) "sizes" "36px" "loading" "eager" "class" "brand__mark") }}
-            <span class="brand__name">Screenly <span class="brand__sub">Apps</span></span>
+            <span class="brand__name">Digital Signage <span class="brand__sub">Apps</span></span>
         </a>
 
         <div class="flex items-center gap-3 sm:gap-5">

--- a/layouts/partials/seo.html
+++ b/layouts/partials/seo.html
@@ -10,7 +10,7 @@
 
         <link rel="canonical" href="{{ .Permalink }}">
         <meta name="description" content="{{ $desc }}">
-        <meta name="robots" content="index, follow">
+        <meta name="robots" content="{{ if hugo.IsProduction }}index, follow{{ else }}noindex, nofollow{{ end }}">
 
         <!-- Open Graph -->
         <meta property="og:site_name" content="{{ .Site.Params.brand }}">

--- a/layouts/robots.txt
+++ b/layouts/robots.txt
@@ -1,4 +1,9 @@
+{{- if hugo.IsProduction -}}
 User-agent: *
 Allow: /
 
 Sitemap: {{ "sitemap.xml" | absURL }}
+{{- else -}}
+User-agent: *
+Disallow: /
+{{- end -}}

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "screenly-app-store",
   "version": "1.0.0",
-  "description": "Free digital signage apps — static site (Hugo + Bun)",
+  "description": "Free digital signage apps, static site (Hugo + Bun)",
   "private": true,
   "license": "AGPL-3.0-only",
   "type": "module",


### PR DESCRIPTION
## Summary

Promotes the current `master` to `production`. This deploys to **`https://signage-apps.com/`** (production `baseURL` is set in the deploy workflow).

### Included changes

- **Wordmark rename:** "Screenly Apps" → "Digital Signage Apps" in header/footer (and README intro), to avoid SEO collision with the "Screenly Apps" product on screenly.io.
- **Production domain:** switched to `signage-apps.com` (`hugo.toml` baseURL, production deploy workflow, local docker image name).
- **Staging:** moved to `stage.signage-apps.com` with `noindex`/`Disallow: /` on all non-production builds; production stays fully indexable.
- **Em dashes:** removed from all source files.

### Deploy / infra notes

- The old domain will be 301'd to `signage-apps.com` separately.
- `signage-apps.com` must be attached as a custom domain to the `app-store-production` Cloudflare Pages project.

🤖 Generated with [Claude Code](https://claude.com/claude-code)