### PR TITLE
Modernize map into a reusable location-picker component

### DIFF
--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -192,12 +192,69 @@
   .modal-close::after { transform: translate(-50%, -50%) rotate(-45deg); }
   .modal-close:hover { border-color: var(--color-accent); }
 
-  /* Config map */
-  #config-map { @apply h-80 w-full overflow-hidden rounded-xl border border-line; }
-  .marker {
-    @apply pointer-events-none absolute left-1/2 top-1/2 text-accent2;
-    transform: translate(-50%, -100%);
+  /* Location picker map (reusable component, see assets/js/lib/location-map.js) */
+  .loc-map {
+    @apply relative w-full overflow-hidden rounded-2xl border border-line-2;
+    height: 22rem;
+    background: var(--color-surface-2);
+    box-shadow: inset 0 1px 0 0 #ffffff0f, 0 24px 60px -34px rgb(0 0 0 / 80%);
   }
+  .loc-map__canvas { @apply absolute inset-0; }
+
+  /* Non-interactive edge vignette + hairline ring for depth. */
+  .loc-map__frame {
+    @apply pointer-events-none absolute inset-0 z-10 rounded-2xl;
+    box-shadow: inset 0 0 0 1px var(--color-line), inset 0 0 70px 0 rgb(12 10 20 / 55%);
+  }
+
+  /* Centre pin, anchored so its tip marks the map centre. */
+  .loc-map__pin {
+    @apply pointer-events-none absolute left-1/2 top-1/2 z-20 text-accent2;
+    transform: translate(-50%, -100%);
+    filter: drop-shadow(0 6px 5px rgb(0 0 0 / 45%));
+  }
+  .loc-map__pin svg { @apply block h-8 w-8; }
+  .loc-map__pin::after {
+    content: ""; @apply absolute left-1/2 -bottom-1 h-2 w-2 -translate-x-1/2 rounded-full;
+    background: var(--color-accent2);
+    box-shadow: 0 0 0 0 rgb(55 182 255 / 55%);
+    animation: ping-accent 2.4s infinite;
+  }
+  @keyframes ping-accent {
+    0% { box-shadow: 0 0 0 0 rgb(55 182 255 / 55%); }
+    70% { box-shadow: 0 0 0 11px rgb(55 182 255 / 0%); }
+    100% { box-shadow: 0 0 0 0 rgb(55 182 255 / 0%); }
+  }
+
+  /* Floating control stack (zoom / locate). */
+  .loc-map__controls { @apply absolute right-3 top-3 z-20 flex flex-col gap-1.5; }
+  .loc-map__btn {
+    @apply grid h-9 w-9 cursor-pointer place-items-center rounded-lg border border-line-2 text-ink transition-colors;
+    background: color-mix(in srgb, var(--color-surface) 78%, transparent);
+    backdrop-filter: blur(8px);
+  }
+  .loc-map__btn:hover { background: var(--color-surface-2); border-color: var(--color-accent); }
+  .loc-map__btn svg { @apply h-4 w-4; }
+  .loc-map__btn.is-busy { @apply pointer-events-none opacity-60; }
+
+  /* Live coordinate readout chip. */
+  .loc-map__readout {
+    @apply absolute bottom-3 left-3 z-20 inline-flex items-center gap-1.5 rounded-full border border-line-2 px-3 py-1.5 font-mono text-xs text-dim;
+    background: color-mix(in srgb, var(--color-surface) 78%, transparent);
+    backdrop-filter: blur(8px);
+  }
+  .loc-map__readout svg { @apply h-3.5 w-3.5 text-accent2; }
+
+  /* Hint that fades once the user starts dragging. */
+  .loc-map__hint {
+    @apply pointer-events-none absolute left-3 top-3 z-20 rounded-full border border-line px-3 py-1 font-mono text-[11px] uppercase tracking-[0.14em] text-faint;
+    background: color-mix(in srgb, var(--color-surface) 70%, transparent);
+    backdrop-filter: blur(8px);
+    transition: opacity .4s ease;
+  }
+  .loc-map.is-touched .loc-map__hint { opacity: 0; }
+
+  .loc-map__fallback { @apply grid h-full place-items-center px-6 text-center text-sm text-faint; }
 
   /* Back to top */
   .back-to-top {

--- a/assets/js/config.js
+++ b/assets/js/config.js
@@ -1,23 +1,7 @@
-/* global google */
-// App configuration page (Weather / Clock): builds the launch URL from the
-// chosen options and an optional map location. The Google Maps API is loaded
-// on demand. It is an external service with no local equivalent.
+// App configuration page (Weather / Air Quality / Clock): builds the launch URL
+// from the chosen options and an optional map location.
 import { buildQueryUrl } from './lib/query-url.js';
-
-const GOOGLE_MAPS_API_KEY = 'AIzaSyD4xizgVnzfyTQgM15V3tvihZxQDAdUuAg';
-
-const MAP_STYLES = [{ "featureType": "administrative", "elementType": "all", "stylers": [{ "lightness": -100 }, { "visibility": "off" }, { "saturation": "-77" }, { "color": "#000000" }] }, { "featureType": "administrative", "elementType": "labels.text.fill", "stylers": [{ "visibility": "on" }, { "color": "#737880" }] }, { "featureType": "landscape", "elementType": "geometry", "stylers": [{ "saturation": "-70" }, { "lightness": "0" }, { "visibility": "on" }, { "color": "#e4e8ee" }] }, { "featureType": "landscape", "elementType": "geometry.fill", "stylers": [{ "hue": "#0066ff" }, { "saturation": "0" }, { "lightness": "0" }] }, { "featureType": "landscape", "elementType": "labels", "stylers": [{ "saturation": "-80" }, { "lightness": "-90" }, { "visibility": "off" }, { "color": "#737880" }] }, { "featureType": "poi", "elementType": "all", "stylers": [{ "saturation": "-80" }, { "lightness": "-70" }, { "visibility": "off" }, { "gamma": "1" }, { "color": "#c0ccdf" }] }, { "featureType": "poi", "elementType": "labels", "stylers": [{ "color": "#737880" }] }, { "featureType": "road", "elementType": "geometry", "stylers": [{ "saturation": "-85" }, { "lightness": "60" }, { "visibility": "on" }, { "color": "#f5f9ff" }] }, { "featureType": "road", "elementType": "labels", "stylers": [{ "saturation": "-70" }, { "lightness": "50" }, { "visibility": "off" }, { "color": "#737880" }] }, { "featureType": "road.local", "elementType": "all", "stylers": [{ "saturation": "0" }, { "lightness": "-11" }, { "visibility": "on" }, { "color": "#f5f9ff" }] }, { "featureType": "road.local", "elementType": "labels", "stylers": [{ "color": "#61656b" }] }, { "featureType": "road.local", "elementType": "labels.text.stroke", "stylers": [{ "visibility": "off" }] }, { "featureType": "transit", "elementType": "geometry", "stylers": [{ "visibility": "simplified" }, { "lightness": "0" }, { "saturation": "0" }, { "color": "#f5f9ff" }] }, { "featureType": "transit", "elementType": "labels", "stylers": [{ "lightness": -100 }, { "visibility": "off" }, { "color": "#737880" }] }, { "featureType": "water", "elementType": "geometry", "stylers": [{ "saturation": "0" }, { "lightness": 100 }, { "visibility": "on" }, { "color": "#c6daf8" }] }, { "featureType": "water", "elementType": "labels", "stylers": [{ "saturation": -100 }, { "lightness": -100 }, { "visibility": "off" }, { "color": "#e4e8ee" }] }];
-
-function loadScript(src) {
-  return new Promise((resolve, reject) => {
-    const script = document.createElement('script');
-    script.src = src;
-    script.async = true;
-    script.addEventListener('load', () => resolve());
-    script.addEventListener('error', () => reject(new Error(`Failed to load ${src}`)));
-    document.head.append(script);
-  });
-}
+import { initLocationMap } from './lib/location-map.js';
 
 function initConfig() {
   const input = document.getElementById('app-form-url');
@@ -29,24 +13,15 @@ function initConfig() {
     input.value = buildQueryUrl(url, params);
   };
 
-  const mapEl = document.getElementById('config-map');
-  if (mapEl && !('google' in window)) {
-    loadScript(`https://maps.googleapis.com/maps/api/js?key=${GOOGLE_MAPS_API_KEY}`)
-      .then(() => {
-        const map = new google.maps.Map(mapEl, {
-          zoom: 16,
-          scrollwheel: false,
-          center: new google.maps.LatLng(51.5287718, -0.2417001),
-          styles: MAP_STYLES,
-        });
-        google.maps.event.addListener(map, 'dragend', () => {
-          const center = map.getCenter();
-          params.lat = center.lat().toFixed(2);
-          params.lng = center.lng().toFixed(2);
-          updateUrl();
-        });
-      })
-      .catch(() => { /* Maps is optional; the URL still works without a location. */ });
+  const mapMount = document.querySelector('[data-location-map]');
+  if (mapMount) {
+    initLocationMap(mapMount, {
+      onChange: ({ lat, lng }) => {
+        params.lat = lat;
+        params.lng = lng;
+        updateUrl();
+      },
+    });
   }
 
   const clockFormat = document.getElementById('clockformat-select');

--- a/assets/js/lib/location-map.js
+++ b/assets/js/lib/location-map.js
@@ -1,0 +1,166 @@
+/* global google */
+// Reusable location-picker map.
+//
+// Wraps the Google Maps JS API (an external service with no local equivalent)
+// in a self-contained component: given a single mount element it builds its own
+// canvas, centre pin, zoom / locate controls and a live coordinate readout,
+// then reports the chosen centre back through an `onChange` callback. The map
+// loads on demand and degrades gracefully when it is unavailable — the rest of
+// the page keeps working without a location.
+
+const GOOGLE_MAPS_API_KEY = 'AIzaSyD4xizgVnzfyTQgM15V3tvihZxQDAdUuAg';
+
+// Custom "Video Wall" map theme, tuned to sit calmly behind the UI chrome.
+const MAP_STYLES = [{ "featureType": "administrative", "elementType": "all", "stylers": [{ "lightness": -100 }, { "visibility": "off" }, { "saturation": "-77" }, { "color": "#000000" }] }, { "featureType": "administrative", "elementType": "labels.text.fill", "stylers": [{ "visibility": "on" }, { "color": "#737880" }] }, { "featureType": "landscape", "elementType": "geometry", "stylers": [{ "saturation": "-70" }, { "lightness": "0" }, { "visibility": "on" }, { "color": "#e4e8ee" }] }, { "featureType": "landscape", "elementType": "geometry.fill", "stylers": [{ "hue": "#0066ff" }, { "saturation": "0" }, { "lightness": "0" }] }, { "featureType": "landscape", "elementType": "labels", "stylers": [{ "saturation": "-80" }, { "lightness": "-90" }, { "visibility": "off" }, { "color": "#737880" }] }, { "featureType": "poi", "elementType": "all", "stylers": [{ "saturation": "-80" }, { "lightness": "-70" }, { "visibility": "off" }, { "gamma": "1" }, { "color": "#c0ccdf" }] }, { "featureType": "poi", "elementType": "labels", "stylers": [{ "color": "#737880" }] }, { "featureType": "road", "elementType": "geometry", "stylers": [{ "saturation": "-85" }, { "lightness": "60" }, { "visibility": "on" }, { "color": "#f5f9ff" }] }, { "featureType": "road", "elementType": "labels", "stylers": [{ "saturation": "-70" }, { "lightness": "50" }, { "visibility": "off" }, { "color": "#737880" }] }, { "featureType": "road.local", "elementType": "all", "stylers": [{ "saturation": "0" }, { "lightness": "-11" }, { "visibility": "on" }, { "color": "#f5f9ff" }] }, { "featureType": "road.local", "elementType": "labels", "stylers": [{ "color": "#61656b" }] }, { "featureType": "road.local", "elementType": "labels.text.stroke", "stylers": [{ "visibility": "off" }] }, { "featureType": "transit", "elementType": "geometry", "stylers": [{ "visibility": "simplified" }, { "lightness": "0" }, { "saturation": "0" }, { "color": "#f5f9ff" }] }, { "featureType": "transit", "elementType": "labels", "stylers": [{ "lightness": -100 }, { "visibility": "off" }, { "color": "#737880" }] }, { "featureType": "water", "elementType": "geometry", "stylers": [{ "saturation": "0" }, { "lightness": 100 }, { "visibility": "on" }, { "color": "#c6daf8" }] }, { "featureType": "water", "elementType": "labels", "stylers": [{ "saturation": -100 }, { "lightness": -100 }, { "visibility": "off" }, { "color": "#e4e8ee" }] }];
+
+const DEFAULT_CENTER = { lat: 51.5287718, lng: -0.2417001 };
+const DEFAULT_ZOOM = 13;
+
+const ICONS = {
+  pin: '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M20 10c0 6-8 12-8 12s-8-6-8-12a8 8 0 0 1 16 0Z"/><circle cx="12" cy="10" r="3"/></svg>',
+  plus: '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" aria-hidden="true"><path d="M12 5v14M5 12h14"/></svg>',
+  minus: '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" aria-hidden="true"><path d="M5 12h14"/></svg>',
+  locate: '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="3.5"/><path d="M12 2v3M12 19v3M2 12h3M19 12h3"/></svg>',
+};
+
+// Load the Maps script once per page and share the promise between callers.
+let mapsPromise;
+function loadGoogleMaps() {
+  if (window.google?.maps) return Promise.resolve();
+  if (!mapsPromise) {
+    mapsPromise = new Promise((resolve, reject) => {
+      const script = document.createElement('script');
+      script.src = `https://maps.googleapis.com/maps/api/js?key=${GOOGLE_MAPS_API_KEY}`;
+      script.async = true;
+      script.addEventListener('load', () => resolve());
+      script.addEventListener('error', () => reject(new Error('Failed to load Google Maps')));
+      document.head.append(script);
+    });
+  }
+  return mapsPromise;
+}
+
+function controlButton(action, label, icon) {
+  const button = document.createElement('button');
+  button.type = 'button';
+  button.className = 'loc-map__btn';
+  button.dataset.act = action;
+  button.setAttribute('aria-label', label);
+  button.innerHTML = icon;
+  return button;
+}
+
+// Build the component chrome inside `mount` and return its parts.
+function buildChrome(mount) {
+  mount.classList.add('loc-map');
+  mount.innerHTML = `
+    <div class="loc-map__canvas"></div>
+    <div class="loc-map__frame"></div>
+    <span class="loc-map__pin">${ICONS.pin}</span>
+    <div class="loc-map__hint">Drag to set location</div>
+  `;
+
+  const controls = document.createElement('div');
+  controls.className = 'loc-map__controls';
+  const locate = controlButton('locate', 'Use my location', ICONS.locate);
+  const zoomIn = controlButton('in', 'Zoom in', ICONS.plus);
+  const zoomOut = controlButton('out', 'Zoom out', ICONS.minus);
+  controls.append(locate, zoomIn, zoomOut);
+
+  const readout = document.createElement('div');
+  readout.className = 'loc-map__readout';
+  readout.innerHTML = `${ICONS.pin}<span data-coords>—</span>`;
+
+  mount.append(controls, readout);
+
+  return {
+    canvas: mount.querySelector('.loc-map__canvas'),
+    coords: readout.querySelector('[data-coords]'),
+    locate,
+    zoomIn,
+    zoomOut,
+  };
+}
+
+/**
+ * Mount a location picker.
+ * @param {HTMLElement} mount  Empty element to render the map into.
+ * @param {object} [options]
+ * @param {{lat:number,lng:number}} [options.center]  Initial centre.
+ * @param {number} [options.zoom]       Initial zoom level.
+ * @param {number} [options.precision]  Decimal places reported for lat/lng.
+ * @param {(coords:{lat:string,lng:string}) => void} [options.onChange]
+ */
+export function initLocationMap(mount, options = {}) {
+  const { center = DEFAULT_CENTER, zoom = DEFAULT_ZOOM, precision = 2, onChange } = options;
+
+  // Host markup may override the defaults via data-attributes, which keeps the
+  // component reusable for apps that want a different starting view.
+  const startCenter = {
+    lat: Number(mount.dataset.lat ?? center.lat),
+    lng: Number(mount.dataset.lng ?? center.lng),
+  };
+  const startZoom = Number(mount.dataset.zoom ?? zoom);
+
+  const { canvas, coords, locate, zoomIn, zoomOut } = buildChrome(mount);
+
+  loadGoogleMaps()
+    .then(() => {
+      const map = new google.maps.Map(canvas, {
+        center: startCenter,
+        zoom: startZoom,
+        minZoom: 3,
+        maxZoom: 18,
+        disableDefaultUI: true,     // we render our own themed controls
+        gestureHandling: 'greedy',  // scroll wheel / pinch zooms directly
+        clickableIcons: false,
+        keyboardShortcuts: false,
+        styles: MAP_STYLES,
+      });
+
+      const renderCoords = () => {
+        const c = map.getCenter();
+        coords.textContent = `${c.lat().toFixed(precision)}, ${c.lng().toFixed(precision)}`;
+      };
+      const emit = () => {
+        const c = map.getCenter();
+        onChange?.({ lat: c.lat().toFixed(precision), lng: c.lng().toFixed(precision) });
+      };
+      const markTouched = () => mount.classList.add('is-touched');
+
+      map.addListener('center_changed', renderCoords);
+      map.addListener('dragstart', markTouched);
+      map.addListener('dragend', emit);
+      renderCoords();
+
+      zoomIn.addEventListener('click', () => map.setZoom(map.getZoom() + 1));
+      zoomOut.addEventListener('click', () => map.setZoom(map.getZoom() - 1));
+
+      locate.addEventListener('click', () => {
+        if (!navigator.geolocation) return;
+        locate.classList.add('is-busy');
+        navigator.geolocation.getCurrentPosition(
+          (pos) => {
+            markTouched();
+            map.panTo({ lat: pos.coords.latitude, lng: pos.coords.longitude });
+            map.setZoom(Math.max(map.getZoom(), 13));
+            // panTo settles asynchronously; report once it does.
+            google.maps.event.addListenerOnce(map, 'idle', () => {
+              renderCoords();
+              emit();
+              locate.classList.remove('is-busy');
+            });
+          },
+          () => locate.classList.remove('is-busy'),
+          { enableHighAccuracy: true, timeout: 8000 },
+        );
+      });
+
+      return map;
+    })
+    .catch(() => {
+      // Maps is optional; show a quiet fallback instead of an empty frame.
+      mount.classList.add('loc-map--unavailable');
+      mount.innerHTML = '<p class="loc-map__fallback">Map unavailable — the link still works without a location.</p>';
+    });
+}

--- a/content/air-quality/index.html
+++ b/content/air-quality/index.html
@@ -18,10 +18,5 @@ links:
     <h2 class="text-2xl">Air quality settings</h2>
     <p class="mt-1 text-dim">Drag the map to pick the location you want to show, or leave it to detect the screen's location automatically.</p>
 
-    <div class="relative mt-5">
-        <div id="config-map"></div>
-        <span class="marker text-3xl">
-            <svg viewBox="0 0 24 24" width="1em" height="1em" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M20 10c0 6-8 12-8 12s-8-6-8-12a8 8 0 0 1 16 0Z"/><circle cx="12" cy="10" r="3"/></svg>
-        </span>
-    </div>
+    <div class="mt-5" data-location-map></div>
 </div>

--- a/content/weather/index.html
+++ b/content/weather/index.html
@@ -18,12 +18,7 @@ links:
     <h2 class="text-2xl">Weather settings</h2>
     <p class="mt-1 text-dim">Drag the map to pick the location you want to show.</p>
 
-    <div class="relative mt-5">
-        <div id="config-map"></div>
-        <span class="marker text-3xl">
-            <svg viewBox="0 0 24 24" width="1em" height="1em" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M20 10c0 6-8 12-8 12s-8-6-8-12a8 8 0 0 1 16 0Z"/><circle cx="12" cy="10" r="3"/></svg>
-        </span>
-    </div>
+    <div class="mt-5" data-location-map></div>
 
     <div class="mt-5">
         <label class="eyebrow" for="clockformat-select">Clock format</label>


### PR DESCRIPTION
## What

Reimplements the location-picker map (used in the **Weather** and **Air Quality** settings) as a reusable, modernized component.

The map logic was previously baked into `config.js` and the marker/container markup was duplicated across both content files. It's now a self-contained module — `assets/js/lib/location-map.js` — that any app can mount with a single `<div data-location-map>`.

## Reusable component

`initLocationMap(mount, { center, zoom, precision, onChange })` builds its own canvas, centre pin, controls and live coordinate readout inside one element, loads the Google Maps script on demand (shared promise across instances), and reports the chosen centre via `onChange`. The starting view is overridable per-instance via `data-lat` / `data-lng` / `data-zoom`.

## Modern look + the missing controls

Per review feedback that the old map was "missing zoom and other things":

- **Zoom in/out buttons** + scroll/pinch zoom (`gestureHandling: 'greedy'`) — the old map had no zoom affordance at all.
- **"Use my location"** button (geolocation).
- **Live lat/lng readout** chip that updates as you drag.
- Animated locator pin, edge-vignette frame, and a hint that fades on first interaction.
- Graceful fallback message if Maps fails to load.

## Notes

- The Google Maps engine and the `lat` / `lng` / `24h` URL-param behaviour are **unchanged** — only the wrapper and visuals changed.
- The existing (domain-restricted) Maps API key is kept, so tiles render on the production/staging domain; on `localhost` Google shows its "for development" / referrer-error screen, which is expected.
- `hugo --minify` builds clean and `eslint` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
