### PR TITLE
Hero screenshot slideshow + footer signup 404 fix

### DIFF
--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -305,3 +305,16 @@
   .reveal { animation: reveal .5s var(--ease, ease) both; }
   @keyframes reveal { from { opacity: 0; transform: translateY(12px); } to { opacity: 1; transform: none; } }
 }
+
+/* Hero slideshow: stacked screenshots that cross-fade (see partials/hero-slideshow.html).
+   The `heroShots` keyframe and per-slide `animation-delay` are generated at build time. */
+.hero-shots { position: relative; aspect-ratio: 16 / 9; }
+.hero-shot { position: absolute; inset: 0; opacity: 0; }
+.hero-shot:first-child { opacity: 1; }   /* fallback: show the first frame if animation is off */
+.hero-shot img { width: 100%; height: 100%; object-fit: cover; display: block; }
+@media (prefers-reduced-motion: no-preference) {
+  .hero-shot {
+    animation: heroShots var(--hero-dur, 40s) linear infinite;
+    will-change: opacity;
+  }
+}

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -26,7 +26,12 @@
 
         <div class="relative">
             <div class="overflow-hidden rounded-2xl border border-line-2 shadow-2xl" style="box-shadow:0 40px 80px -30px rgb(122 90 248 / 55%)">
-                {{ partial "optimg.html" (dict "src" "img/hero-3.jpg" "alt" "Screenly running on a display" "widths" (slice 640 960 1280) "sizes" "(min-width:1024px) 40vw, 90vw" "loading" "eager") }}
+                {{- /* Every app, but collapse the many RSS feeds to one representative screenshot. */ -}}
+                {{ $rssOne := first 1 (where (where .Site.RegularPages "Section" "rss") "File.ContentBaseName" "nasa-iotd") }}
+                {{ $heroPages := sort ((where .Site.RegularPages "Section" "!=" "rss") | append $rssOne) "Weight" }}
+                {{ partial "hero-slideshow.html" (dict
+                    "pages" $heroPages
+                    "first" (dict "src" "img/hero-3.jpg" "alt" "Screenly running on a display")) }}
             </div>
         </div>
     </div>

--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -17,7 +17,7 @@
                     <span class="tag">For business · Free trial</span>
                     <h3 class="mt-2 text-2xl">Screenly</h3>
                     <p class="mt-2 flex-1 text-sm text-dim">Managed, secure digital signage for teams and fleets, with support and remote fleet management. Start a free trial.</p>
-                    <a class="btn-primary mt-6 self-start" href="https://login.screenlyapp.com/signup" target="_blank" rel="noopener">Start free trial {{ partial "icon.html" "arrow-right" }}</a>
+                    <a class="btn-primary mt-6 self-start" href="https://login.screenlyapp.com/sign-up" target="_blank" rel="noopener">Start free trial {{ partial "icon.html" "arrow-right" }}</a>
                 </div>
             </div>
         </section>

--- a/layouts/partials/hero-slideshow.html
+++ b/layouts/partials/hero-slideshow.html
@@ -1,0 +1,60 @@
+{{- /*
+  Hero slideshow: a pure-CSS crossfading loop.
+
+  Renders the given "first" image, then loops through every page's app
+  screenshot, so newly added apps are picked up automatically. All slides are
+  stacked and cross-fade via a single keyframe; the keyframe stops and the
+  per-slide delays are computed here at build time, so the timing stays correct
+  for any number of slides.
+
+  Params (dict):
+    pages  (required) page collection; each page's .Params.app.image is a slide
+    first  (optional) dict {src, alt} shown first and kept in the loop
+    hold   (optional) seconds each slide stays up, incl. fade (default 4)
+    fade   (optional) crossfade seconds (default 0.8)
+*/ -}}
+{{- $hold := .hold | default 4.0 -}}
+{{- $fade := .fade | default 0.8 -}}
+
+{{- /* Build the slide list: the "first" image, then one per page. */ -}}
+{{- $slides := slice -}}
+{{- with .first -}}
+  {{- $slides = $slides | append (dict "src" .src "alt" (.alt | default "")) -}}
+{{- end -}}
+{{- range .pages -}}
+  {{- with .Params.app.image -}}
+    {{- $slides = $slides | append (dict "src" (printf "img/%s" .) "alt" $.Title) -}}
+  {{- end -}}
+{{- end -}}
+
+{{- $n := len $slides -}}
+{{- if le $n 1 -}}
+  {{- /* Nothing to animate: render the single image. */ -}}
+  {{- with index $slides 0 -}}
+    {{ partial "optimg.html" (dict "src" .src "alt" .alt "widths" (slice 640 960 1280) "sizes" "(min-width:1024px) 40vw, 90vw" "loading" "eager") }}
+  {{- end -}}
+{{- else -}}
+  {{- $dur := mul $n $hold -}}
+  {{- /* Keyframe stops as a percent of the full cycle. */ -}}
+  {{- $slotPct := div 100.0 $n -}}
+  {{- $fadePct := div (mul $fade 100.0) $dur -}}
+  {{- $outPct := add $slotPct $fadePct -}}
+  <div class="hero-shots" style="--hero-dur:{{ printf "%.3f" $dur }}s">
+    <style>
+      @keyframes heroShots {
+        0% { opacity: 0 }
+        {{ printf "%.4f" $fadePct }}% { opacity: 1 }
+        {{ printf "%.4f" $slotPct }}% { opacity: 1 }
+        {{ printf "%.4f" $outPct }}% { opacity: 0 }
+        100% { opacity: 0 }
+      }
+    </style>
+    {{- range $i, $s := $slides -}}
+      {{- /* Negative delay on the first slide so it is fully shown at load. */ -}}
+      {{- $delay := sub (mul $i $hold) $fade -}}
+      <div class="hero-shot" style="animation-delay:{{ printf "%.3f" $delay }}s"{{ if gt $i 0 }} aria-hidden="true"{{ end }}>
+        {{ partial "optimg.html" (dict "src" $s.src "alt" $s.alt "widths" (slice 640 960 1280) "sizes" "(min-width:1024px) 40vw, 90vw" "loading" (cond (eq $i 0) "eager" "lazy")) }}
+      </div>
+    {{- end -}}
+  </div>
+{{- end -}}


### PR DESCRIPTION
## Summary

Two changes from a site 404 audit and a hero-section request:

- **Fix a site-wide 404**: the footer's "Start free trial" CTA pointed at `login.screenlyapp.com/signup` (404). Updated to `/sign-up` (verified 200). This was the only broken link found in a full audit of all built pages + external URLs.
- **Animated hero slideshow**: the static hero image is now a pure-CSS crossfade loop that starts on `hero-3.jpg` and cycles through the app screenshots, looping seamlessly.

## How the slideshow works

- New helper `layouts/partials/hero-slideshow.html` stacks the slides and computes the `@keyframes` stops and per-slide `animation-delay` at build time, so timing stays correct for any number of slides.
- `index.html` feeds it every standalone app **plus one representative RSS screenshot** (NASA Image of the Day) — the 22 near-identical RSS feeds are collapsed to one so the loop stays tight (10 slides, ~40s).
- **Auto-populating**: new apps added to the content dir appear in the hero automatically; new RSS feeds join the grid but don't bloat the hero.
- `app.css` holds the structural styles (16:9 frame, `object-fit: cover`) with a `prefers-reduced-motion` fallback that shows just the first static frame.

## Verification

- Hugo builds clean (no warnings); internal link audit shows 0 broken links.
- Playwright render confirms `hero-3.jpg` is the only visible frame at load, then the screenshots crossfade and loop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)