### PR TITLE
Add UTM parameters to Anthias and Screenly CTAs

### DIFF
--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -11,13 +11,13 @@
                     <span class="tag">Free · Open source</span>
                     <h3 class="mt-2 text-2xl">Anthias</h3>
                     <p class="mt-2 flex-1 text-sm text-dim">Self-host the open-source digital signage player on a Raspberry Pi or any Linux device. Free, forever.</p>
-                    <a class="btn-ghost mt-6 self-start" href="https://anthias.screenly.io" target="_blank" rel="noopener">Get Anthias {{ partial "icon.html" "arrow-right" }}</a>
+                    <a class="btn-ghost mt-6 self-start" href="https://anthias.screenly.io?utm_source=signage-apps.com&amp;utm_medium=referral&amp;utm_campaign=app-store" target="_blank" rel="noopener">Get Anthias {{ partial "icon.html" "arrow-right" }}</a>
                 </div>
                 <div class="panel" style="border-color:var(--color-line-2)">
                     <span class="tag">For business · Free trial</span>
                     <h3 class="mt-2 text-2xl">Screenly</h3>
                     <p class="mt-2 flex-1 text-sm text-dim">Managed, secure digital signage for teams and fleets, with support and remote fleet management. Start a free trial.</p>
-                    <a class="btn-primary mt-6 self-start" href="https://login.screenlyapp.com/sign-up" target="_blank" rel="noopener">Start free trial {{ partial "icon.html" "arrow-right" }}</a>
+                    <a class="btn-primary mt-6 self-start" href="https://login.screenlyapp.com/sign-up?utm_source=signage-apps.com&amp;utm_medium=referral&amp;utm_campaign=app-store" target="_blank" rel="noopener">Start free trial {{ partial "icon.html" "arrow-right" }}</a>
                 </div>
             </div>
         </section>


### PR DESCRIPTION
## What

Adds standard UTM tracking parameters to the two outbound conversion CTAs in the footer so clicks from the app store are attributed correctly in analytics.

| CTA | UTM params |
|-----|-----------|
| Get Anthias (`anthias.screenly.io`) | `utm_source=signage-apps.com&utm_medium=referral&utm_campaign=app-store` |
| Start free trial (`login.screenlyapp.com/sign-up`) | `utm_source=signage-apps.com&utm_medium=referral&utm_campaign=app-store` |

## UTM scheme

- **utm_source** = `signage-apps.com` — the referring site (matches `baseURL`)
- **utm_medium** = `referral` — outbound link from the app store
- **utm_campaign** = `app-store` — identifies this property as the campaign

Uses `&amp;` in the HTML source (valid HTML; the literal `&` reaches the destination). Social/mailto/GitHub links were left untouched as they are not conversion CTAs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)