### PR TITLE
CI: gate deploys on lint/test via reusable workflow

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,8 +1,15 @@
 name: CI
 
 on:
+  workflow_call:
   push:
+    branches-ignore:
+      - master
+      - production
   pull_request:
+    branches-ignore:
+      - master
+      - production
 
 env:
   HUGO_VERSION: 0.157.0

--- a/.github/workflows/deploy-production.yaml
+++ b/.github/workflows/deploy-production.yaml
@@ -12,7 +12,12 @@ env:
   HUGO_VERSION: 0.157.0
 
 jobs:
+  ci:
+    name: CI
+    uses: ./.github/workflows/ci.yaml
+
   deploy:
+    needs: ci
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -34,12 +39,6 @@ jobs:
         with:
           hugo-version: ${{ env.HUGO_VERSION }}
           extended: true
-
-      - name: Lint
-        run: bun run lint
-
-      - name: Test
-        run: bun test
 
       - name: Build
         run: hugo --gc --minify --baseURL "https://signage-apps.com/"

--- a/.github/workflows/deploy-stage.yaml
+++ b/.github/workflows/deploy-stage.yaml
@@ -12,7 +12,12 @@ env:
   HUGO_VERSION: 0.157.0
 
 jobs:
+  ci:
+    name: CI
+    uses: ./.github/workflows/ci.yaml
+
   deploy:
+    needs: ci
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -34,12 +39,6 @@ jobs:
         with:
           hugo-version: ${{ env.HUGO_VERSION }}
           extended: true
-
-      - name: Lint
-        run: bun run lint
-
-      - name: Test
-        run: bun test
 
       - name: Build
         run: hugo --gc --minify --environment staging --baseURL "https://stage.signage-apps.com/"


### PR DESCRIPTION
## Summary
Restructure the GitHub Actions workflows so that linting and tests must pass **before** a deploy publishes, using a dependency structure.

- `ci.yaml` becomes a **reusable workflow** (`workflow_call`) that still runs standalone on feature branches. Its standalone `push`/`pull_request` triggers now `branches-ignore: master, production` to avoid double runs.
- `deploy-stage.yaml` and `deploy-production.yaml` each gain a `ci` job that invokes the reusable workflow, and their `deploy` job now `needs: ci`.
- Removed the duplicated `Lint`/`Test` steps from the deploy jobs (they run in the `ci` job instead). Environment-specific `Build` (with the right `baseURL`) and `Publish` remain.

### Flow
```
push/PR to master     ──► deploy-stage:      [ci] ──► [deploy] (Build + Publish)
push/PR to production ──► deploy-production:  [ci] ──► [deploy]
```

## Notes
- Lint/test now gate deploys — a failing lint/test blocks publish.
- No duplicate CI runs on `master`/`production`.
- `Publish` keeps its `if: github.event_name != 'pull_request'` guard, so PRs validate without deploying.
- ⚠️ If branch protection has required status checks, the check names may have changed (deploy workflows now surface a `CI` job) — update required-check names in repo settings to match.

🤖 Generated with [Claude Code](https://claude.com/claude-code)