### PR TITLE
Analytics: switch to GA4 via Hugo's built-in template

### DIFF
--- a/hugo.toml
+++ b/hugo.toml
@@ -28,6 +28,9 @@ disableKinds = ["taxonomy", "term", "rss", "section"]
     github = "https://github.com/orgs/Screenly/"
     medium = "https://news.screenly.io/"
 
+[services.googleAnalytics]
+  ID = "G-P2TYEQ4NTL"
+
 [markup.goldmark.renderer]
   # The app description pages contain inline HTML (links, etc.).
   unsafe = true

--- a/layouts/partials/foot.html
+++ b/layouts/partials/foot.html
@@ -1,12 +1,5 @@
-        <!-- Google Analytics -->
-        <script>
-         (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-         (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-         m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-         })(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
-         ga('create', 'UA-37846380-1', 'auto');
-         ga('send', 'pageview');
-        </script>
+        <!-- Google Analytics (GA4, production builds only) -->
+        {{ if hugo.IsProduction }}{{ template "_internal/google_analytics.html" . }}{{ end }}
 
         <!-- Site JavaScript (bundled locally by Hugo's esbuild from Bun deps) -->
         {{ $main := resources.Get "js/main.js" | js.Build (dict "minify" true "target" "es2018") | fingerprint }}


### PR DESCRIPTION
## What

Hooks up Google Analytics 4 (property `G-P2TYEQ4NTL`) using Hugo's built-in `_internal/google_analytics.html` template.

## Changes

- **`hugo.toml`** — register the GA4 measurement ID under `[services.googleAnalytics]`.
- **`layouts/partials/foot.html`** — replace the old hardcoded Universal Analytics snippet (`analytics.js`, `UA-37846380-1`) with the built-in GA4 template.

## Why

- The previous snippet used **Universal Analytics**, which Google shut down in 2023 — it was sending to a dead property.
- In Hugo 0.157 the built-in template renders whenever an ID is set (no environment self-gating), so the call is wrapped in `{{ if hugo.IsProduction }}`. This keeps `hugo server` (development) from polluting the production property with localhost traffic; only `hugo --minify` builds emit the tag.

## Verification

- Prod build (`hugo --minify`): emits exactly one `gtag/js?id=G-P2TYEQ4NTL` tag.
- Dev build (`hugo --environment development`): emits zero GA references.

🤖 Generated with [Claude Code](https://claude.com/claude-code)