### PR TITLE
Release: GA4 analytics to production

### DIFF
--- a/hugo.toml
+++ b/hugo.toml
@@ -28,6 +28,9 @@ disableKinds = ["taxonomy", "term", "rss", "section"]
     github = "https://github.com/orgs/Screenly/"
     medium = "https://news.screenly.io/"
 
+[services.googleAnalytics]
+  ID = "G-P2TYEQ4NTL"
+
 [markup.goldmark.renderer]
   # The app description pages contain inline HTML (links, etc.).
   unsafe = true

--- a/layouts/partials/foot.html
+++ b/layouts/partials/foot.html
@@ -1,12 +1,5 @@
-        <!-- Google Analytics -->
-        <script>
-         (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-         (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-         m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-         })(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
-         ga('create', 'UA-37846380-1', 'auto');
-         ga('send', 'pageview');
-        </script>
+        <!-- Google Analytics (GA4, production builds only) -->
+        {{ if hugo.IsProduction }}{{ template "_internal/google_analytics.html" . }}{{ end }}
 
         <!-- Site JavaScript (bundled locally by Hugo's esbuild from Bun deps) -->
         {{ $main := resources.Get "js/main.js" | js.Build (dict "minify" true "target" "es2018") | fingerprint }}


### PR DESCRIPTION
Promotes `master` to `production` (Cloudflare Pages deploy).

## Included

- **#26 — Analytics: switch to GA4 via Hugo's built-in template**
  Replaces the dead Universal Analytics snippet with GA4 (`G-P2TYEQ4NTL`) via Hugo's built-in template, gated to production builds.

Merging this triggers the production deploy workflow to `app-store-production`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)