### PR TITLE
Add app manifest spec, schema, and store index

### DIFF
--- a/docs/app-manifest.md
+++ b/docs/app-manifest.md
@@ -1,0 +1,237 @@
+# App manifest (`signage-app.json`)
+
+Every signage app publishes a machine-readable manifest describing **what it is**
+and **how to configure it**. The app is the source of truth for its own settings.
+The [app store](https://signage-apps.com) renders its config pages from this file
+(instead of hand-written per-app forms) and publishes an index that points at
+every app's manifest. Signage players consume the same manifests directly. Do not
+re-implement an app's settings form by hand anywhere else — read it from here.
+
+## Where it lives
+
+Serve the manifest from a stable, well-known path on the app's own origin:
+
+```
+https://<app>.srly.io/.well-known/signage-app.json
+```
+
+Requirements:
+
+- `Content-Type: application/json`
+- `Access-Control-Allow-Origin: *` — consumers fetch it cross-origin.
+- Reachable by an anonymous client (no auth).
+
+## Shape
+
+```jsonc
+{
+  "manifestVersion": "1",          // required. Bump only on breaking changes.
+  "id": "weather",                 // required. Stable slug, unique in the store.
+  "name": "Weather",               // required. Human title.
+  "description": "…",              // required. Full sentence(s) for the detail page.
+  "summary": "Live local weather for any display.", // optional. One-line card text.
+
+  "vendor": "Screenly",            // optional.
+  "tags": ["Weather", "Clock"],    // optional. Free-form categories.
+
+  "icon": "https://…/icon.svg",            // optional. Square, transparent.
+  "screenshots": ["https://…/shot.jpg"],   // optional. First is the primary.
+
+  "homepage": "https://weather.srly.io/",                       // optional.
+  "source":   "https://github.com/Screenly-Labs/weather-app",   // optional.
+  "support":  "https://github.com/Screenly-Labs/weather-app/issues", // optional.
+
+  // Playback hints a consumer may apply as defaults. Optional.
+  "playback": {
+    "duration": 30,          // seconds on screen
+    "refreshIntervalS": 3600 // how often the page should reload
+  },
+
+  // JSON Schema (draft 2020-12) describing the configurable settings.
+  // Omit entirely if the app takes no settings.
+  "settings": { … },
+
+  // How settings serialize into the launch URL. Required.
+  "launch": { … }
+}
+```
+
+## `settings` — a JSON Schema object
+
+Settings are a typed form. Use standard JSON Schema for structure, types,
+defaults, `enum`, and validation (`minimum`, `maxLength`, `pattern`, …). Layer UI
+hints on top with `x-*` keywords (which validators ignore):
+
+| keyword         | meaning |
+|-----------------|---------|
+| `x-widget`      | Which control to render. See vocabulary below. Inferred from `type`/`enum` if absent. |
+| `x-enumLabels`  | Array of human labels parallel to `enum` (same length/order). |
+| `x-format`      | For array/object items: a template composing sub-fields into one string token, e.g. `"{zone}|{label}"`. An empty interpolated field drops itself **and its adjacent separator**, so a blank `label` yields just `zone`. |
+| `x-group`       | Optional label to visually group fields. |
+
+### `x-widget` vocabulary
+
+| value          | applies to        | notes |
+|----------------|-------------------|-------|
+| `text`         | `string`          | default for free-text strings |
+| `select`       | `string` + `enum` | default when `enum` present |
+| `toggle`       | `boolean`         | |
+| `number`       | `number`/`integer`| |
+| `url`          | `string`          | validated as a URL |
+| `location-map` | `object` `{lat,lng}` | draggable map; bind it to a single object property so the pair stays grouped |
+| `timezone`     | `string`          | IANA tz picker |
+
+Consumers that don't recognise a widget fall back to the type's default control,
+so a manifest is never unrenderable.
+
+## `launch` — settings → URL
+
+```jsonc
+"launch": {
+  "baseUrl": "https://weather.srly.io/",  // required
+  "template": "{?location*,24h}"          // RFC 6570 URI Template over setting names
+}
+```
+
+- `template` is an [RFC 6570](https://datatracker.ietf.org/doc/html/rfc6570) URI
+  Template whose variables are the `settings` property names.
+- **Put every query parameter in one `{?…}` expression.** Do not chain
+  `{?a}{&b}` — each expression expands independently, so `{&b}` emits a stray
+  leading `&` (a malformed `…/&b=` URL) whenever the earlier `{?a}` group is
+  empty.
+- **Only *undefined* variables are dropped.** An empty string still expands to
+  `name=`. So the URL builder must **omit** a setting that is empty or at its
+  default (pass it as undefined) — never feed `""` into the template.
+- Map each setting type to the wire form:
+  - **object** → explode (`{?location*}`) to emit its keys as params:
+    `?lat=…&lng=…`.
+  - **array** → explode (`{?tz*}`) to repeat the param: `tz=…&tz=…`; compose
+    composite item tokens with `x-format`.
+  - **boolean** → the string `1` when true, **omitted** when false. Accept
+    `foo=1`, not a bare `foo` flag.
+  - keep each param name identical to its setting name so the template stays 1:1.
+- A setting/param name may start with a digit (e.g. `24h`) — valid per RFC 6570,
+  but a few template libraries reject it, so verify your consumer handles it.
+- RFC 6570 percent-encodes reserved characters (`/`, `|`, spaces). An app that
+  documents literal reserved chars in its URLs must also accept the encoded forms.
+- Omit `template` for apps with no settings; `baseUrl` is then the launch URL.
+
+## Worked examples
+
+### Weather (`lat`/`lng` + clock format)
+
+```jsonc
+{
+  "manifestVersion": "1",
+  "id": "weather",
+  "name": "Weather",
+  "description": "A live weather display with the location and clock format you choose.",
+  "summary": "Live local weather for any display.",
+  "tags": ["Weather", "Clock"],
+  "source": "https://github.com/Screenly-Labs/weather-app",
+  "support": "https://github.com/Screenly-Labs/weather-app/issues",
+  "playback": { "duration": 30, "refreshIntervalS": 3600 },
+  "settings": {
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "type": "object",
+    "properties": {
+      "location": {
+        "type": "object", "title": "Location", "x-widget": "location-map",
+        "properties": {
+          "lat": { "type": "number" },
+          "lng": { "type": "number" }
+        }
+      },
+      "24h": {
+        "type": "string", "title": "Clock format", "default": "",
+        "enum": ["", "0", "1"],
+        "x-enumLabels": ["Default", "12-hour", "24-hour"]
+      }
+    }
+  },
+  "launch": {
+    "baseUrl": "https://weather.srly.io/",
+    "template": "{?location*,24h}"
+  }
+}
+```
+
+### World Clock (repeated cities, composite tokens, flag)
+
+```jsonc
+{
+  "manifestVersion": "1",
+  "id": "world-clock",
+  "name": "World Clock",
+  "description": "A full-screen board of city clocks for any display.",
+  "summary": "Every time zone that matters, on one screen.",
+  "tags": ["Clock"],
+  "source": "https://github.com/Screenly-Labs/world-clock",
+  "support": "https://github.com/Screenly-Labs/world-clock/issues",
+  "settings": {
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "type": "object",
+    "properties": {
+      "title": { "type": "string", "title": "Board title" },
+      "tz": {
+        "type": "array", "title": "Cities",
+        "items": {
+          "type": "object",
+          "x-widget": "timezone",
+          "x-format": "{zone}|{label}",
+          "properties": {
+            "zone":  { "type": "string" },
+            "label": { "type": "string" }
+          },
+          "required": ["zone"]
+        }
+      },
+      "locale": {
+        "type": "string", "title": "Language & region", "default": "",
+        "enum": ["", "en-US", "de-DE", "fr-FR", "es-ES", "ja-JP"],
+        "x-enumLabels": ["English (UK)", "English (US)", "German", "French", "Spanish", "Japanese"]
+      },
+      "format": {
+        "type": "string", "title": "Clock format", "default": "",
+        "enum": ["", "12", "24"],
+        "x-enumLabels": ["Match language", "12-hour", "24-hour"]
+      },
+      "seconds": { "type": "boolean", "title": "Show seconds", "default": false }
+    }
+  },
+  "launch": {
+    "baseUrl": "https://world-clock.srly.io/",
+    "template": "{?title,tz*,locale,format,seconds}"
+  }
+}
+```
+
+> Every param sits in the one `{?…}` expression, so whichever value is present
+> first gets the `?`. `tz*` explodes the array and `x-format` composes each item
+> (`Zone|Label`, or just `Zone` when the label is blank). Two backwards-compatible
+> app-side tweaks make it expressible: accept `seconds=1` (a value, not a bare
+> flag) and `tz=Zone|Label` repeated. Note RFC 6570 percent-encodes the `/` and
+> `|` in each token (`Europe%2FStockholm%7CHome`), so the app must accept the
+> encoded forms — it won't be the byte-for-byte literal URL the app documents.
+
+### No-settings app (e.g. Quotes)
+
+```jsonc
+{
+  "manifestVersion": "1",
+  "id": "quotes",
+  "name": "Quotes",
+  "description": "A full-screen quotation for any display.",
+  "summary": "A fresh quote for any display.",
+  "tags": ["Quotes"],
+  "source": "https://github.com/Screenly-Labs/quotes",
+  "support": "https://github.com/Screenly-Labs/quotes/issues",
+  "launch": { "baseUrl": "https://quotes.srly.io/" }
+}
+```
+
+## Validation
+
+Manifests validate against
+[`static/schemas/signage-app-manifest.schema.json`](../static/schemas/signage-app-manifest.schema.json).
+The store's index build rejects any app whose manifest fails validation.

--- a/docs/app-manifest.md
+++ b/docs/app-manifest.md
@@ -41,10 +41,13 @@ Requirements:
   "source":   "https://github.com/Screenly-Labs/weather-app",   // optional.
   "support":  "https://github.com/Screenly-Labs/weather-app/issues", // optional.
 
-  // Playback hints a consumer may apply as defaults. Optional.
+  // How the app paces itself. Optional. There is deliberately no "duration":
+  // total time on screen is a playlist decision, not an app property.
   "playback": {
-    "duration": 30,          // seconds on screen
-    "refreshIntervalS": 3600 // how often the page should reload
+    "pacing": "stepped",     // "fixed" = one static page | "stepped" = self-advances
+    "loops": true,           // stepped only: cycles forever vs plays once and stops
+    "stepSeconds": 12,       // stepped only: dwell per internal step
+    "refreshIntervalS": 3600 // how often it reloads its data
   },
 
   // JSON Schema (draft 2020-12) describing the configurable settings.
@@ -55,6 +58,26 @@ Requirements:
   "launch": { … }
 }
 ```
+
+## `playback` — pacing, not duration
+
+`playback` describes how the app paces its own content so a player can hand off
+sensibly. It deliberately has **no on-screen duration** — how long an asset stays
+up is a playlist decision, not an app property.
+
+- `pacing` — `"fixed"` (one static page) or `"stepped"` (the app advances through
+  its own content, e.g. the RSS reader rotating stories).
+- `loops` — stepped apps only: `true` cycles forever, `false` plays once and stops.
+- `stepSeconds` — stepped apps only: the dwell per internal step. Lets a player
+  land its hand-off on a step boundary instead of mid-item.
+- `refreshIntervalS` — how often the page reloads its data.
+
+**These are defaults.** Anything the user can change is exposed as a `settings`
+field instead, and that field is then the single source of truth — give it a
+matching `default` and omit it from `playback`. A player reads the effective
+value from the setting, falling back to `playback`. So a fixed rotation lives in
+`playback.stepSeconds`; a user-adjustable rotation lives in `settings` (e.g. a
+`stepSeconds` number field) and drives both the launch URL and the pacing.
 
 ## `settings` — a JSON Schema object
 
@@ -130,7 +153,7 @@ so a manifest is never unrenderable.
   "tags": ["Weather", "Clock"],
   "source": "https://github.com/Screenly-Labs/weather-app",
   "support": "https://github.com/Screenly-Labs/weather-app/issues",
-  "playback": { "duration": 30, "refreshIntervalS": 3600 },
+  "playback": { "pacing": "fixed", "refreshIntervalS": 3600 },
   "settings": {
     "$schema": "https://json-schema.org/draft/2020-12/schema",
     "type": "object",

--- a/docs/app-manifest.md
+++ b/docs/app-manifest.md
@@ -79,6 +79,11 @@ value from the setting, falling back to `playback`. So a fixed rotation lives in
 `playback.stepSeconds`; a user-adjustable rotation lives in `settings` (e.g. a
 `stepSeconds` number field) and drives both the launch URL and the pacing.
 
+**`playback` is optional — omit it entirely when there's nothing to pace.** A
+single-shot page like Quotes (a fresh quote on each load, no rotation, no data
+refresh) has no pacing to describe, so it leaves `playback` out rather than
+asserting `pacing: "fixed"`.
+
 ## `settings` — a JSON Schema object
 
 Settings are a typed form. Use standard JSON Schema for structure, types,

--- a/hugo.toml
+++ b/hugo.toml
@@ -7,6 +7,17 @@ enableGitInfo = true
 # No blog/taxonomies/section listings on this site. Keep the output minimal.
 disableKinds = ["taxonomy", "term", "rss", "section"]
 
+# Emit /manifest.json alongside the home page: a pointers-only index of every
+# app's self-hosted manifest (see docs/app-manifest.md).
+[outputs]
+  home = ["HTML", "appindex"]
+
+[outputFormats.appindex]
+  mediaType = "application/json"
+  baseName = "manifest"
+  isPlainText = true
+  notAlternative = true
+
 # Populate <lastmod> in Hugo's generated sitemap: prefer the git commit date,
 # fall back to the file modification time so it is always present.
 [frontmatter]

--- a/layouts/index.appindex.json
+++ b/layouts/index.appindex.json
@@ -1,0 +1,28 @@
+{{- /*
+  /manifest.json — pointers-only index of every app's self-hosted manifest.
+  One entry per distinct app origin (dedup so the RSS reader's many curated feed
+  pages collapse to a single manifest). Each app publishes the actual file at
+  /.well-known/signage-app.json on its own origin; see docs/app-manifest.md.
+*/ -}}
+{{- $apps := slice -}}
+{{- $seen := slice -}}
+{{- range .Site.RegularPages -}}
+  {{- with .Params.app -}}
+    {{- with .url -}}
+      {{- $u := urls.Parse . -}}
+      {{- $origin := printf "%s://%s" $u.Scheme $u.Host -}}
+      {{- if not (in $seen $origin) -}}
+        {{- $seen = $seen | append $origin -}}
+        {{- $id := index (split $u.Host ".") 0 -}}
+        {{- $apps = $apps | append (dict
+          "id" $id
+          "manifest" (printf "%s/.well-known/signage-app.json" $origin)) -}}
+      {{- end -}}
+    {{- end -}}
+  {{- end -}}
+{{- end -}}
+{{- $out := dict
+  "indexVersion" "1"
+  "updated" (.Site.Lastmod.Format "2006-01-02T15:04:05Z07:00")
+  "apps" (sort $apps "id") -}}
+{{ jsonify (dict "indent" "  ") $out }}

--- a/static/schemas/signage-app-manifest.schema.json
+++ b/static/schemas/signage-app-manifest.schema.json
@@ -1,0 +1,76 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://signage-apps.com/schemas/signage-app-manifest.schema.json",
+  "title": "Signage app manifest",
+  "description": "Self-describing manifest published by a signage app at /.well-known/signage-app.json. See docs/app-manifest.md.",
+  "type": "object",
+  "required": ["manifestVersion", "id", "name", "description", "launch"],
+  "additionalProperties": false,
+  "properties": {
+    "manifestVersion": {
+      "description": "Manifest format version. Bump only on breaking changes.",
+      "const": "1"
+    },
+    "id": {
+      "description": "Stable slug, unique within the store.",
+      "type": "string",
+      "pattern": "^[a-z0-9]+(?:-[a-z0-9]+)*$"
+    },
+    "name": { "type": "string", "minLength": 1 },
+    "description": { "type": "string", "minLength": 1 },
+    "summary": { "type": "string" },
+    "vendor": { "type": "string" },
+    "tags": {
+      "type": "array",
+      "items": { "type": "string" },
+      "uniqueItems": true
+    },
+    "icon": { "type": "string", "format": "uri" },
+    "screenshots": {
+      "type": "array",
+      "items": { "type": "string", "format": "uri" }
+    },
+    "homepage": { "type": "string", "format": "uri" },
+    "source": { "type": "string", "format": "uri" },
+    "support": { "type": "string", "format": "uri" },
+    "playback": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "duration": { "type": "integer", "minimum": 1 },
+        "refreshIntervalS": { "type": "integer", "minimum": 0, "maximum": 86400 }
+      }
+    },
+    "settings": {
+      "description": "JSON Schema (draft 2020-12) describing configurable settings. Object at the root.",
+      "type": "object",
+      "required": ["type", "properties"],
+      "properties": {
+        "type": { "const": "object" },
+        "properties": { "type": "object" }
+      }
+    },
+    "launch": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["baseUrl"],
+      "properties": {
+        "baseUrl": { "type": "string", "format": "uri" },
+        "template": {
+          "description": "RFC 6570 URI Template over the settings property names. Omit when there are no settings.",
+          "type": "string"
+        }
+      }
+    }
+  },
+  "allOf": [
+    {
+      "$comment": "A template only makes sense when settings exist.",
+      "if": {
+        "properties": { "launch": { "required": ["template"] } },
+        "required": ["launch"]
+      },
+      "then": { "required": ["settings"] }
+    }
+  ]
+}

--- a/static/schemas/signage-app-manifest.schema.json
+++ b/static/schemas/signage-app-manifest.schema.json
@@ -34,10 +34,13 @@
     "source": { "type": "string", "format": "uri" },
     "support": { "type": "string", "format": "uri" },
     "playback": {
+      "description": "Pacing defaults. No on-screen duration by design. Anything user-configurable belongs in settings instead. See docs/app-manifest.md.",
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "duration": { "type": "integer", "minimum": 1 },
+        "pacing": { "enum": ["fixed", "stepped"] },
+        "loops": { "type": "boolean" },
+        "stepSeconds": { "type": "integer", "minimum": 1 },
         "refreshIntervalS": { "type": "integer", "minimum": 0, "maximum": 86400 }
       }
     },


### PR DESCRIPTION
## What

Introduces a self-describing per-app **manifest** so the app store and signage players (Anthias, Screenly) can render an app's config form and build its launch URL from one source of truth — the app itself — instead of hand-coding each form in multiple places.

Each app publishes `signage-app.json` at `/.well-known/signage-app.json` on its own origin. The store consumes it to render config pages and publishes a thin index pointing at every app's manifest.

## Contents

- **`docs/app-manifest.md`** — the manifest blueprint any app author follows: identity fields, a JSON Schema `settings` block with `x-widget`/`x-format` UI hints, and an RFC 6570 `launch` template that maps settings → URL. Worked examples for a simple app (Weather), a hard one (World Clock: repeated params, composite tokens, boolean flag), and a no-settings app (Quotes).
- **`static/schemas/signage-app-manifest.schema.json`** — JSON Schema that validates a manifest.
- **`layouts/index.appindex.json` + `hugo.toml`** — emit `/manifest.json`, a pointers-only index of every app's manifest URL, deduped by origin (so the 22 curated RSS feed pages collapse to one `rss` entry). Regenerated from content on each build.

## Design decisions

- **Settings = JSON Schema**, not JSON-LD — settings are a typed form; JSON Schema gives types/defaults/validation and free-ish form generation on consumers. (schema.org JSON-LD stays a separate SEO-rendering concern.)
- **Launch = RFC 6570 URI Template** — one standard, no bespoke param-building engine. Kept expressible by two small backwards-compatible app-side conventions: booleans as `foo=1` (not a bare flag), and array explode for repeated params.
- **Index is pointers-only + apps-first** — the app owns its manifest; the store index just references it (no build-time fetch).

## Verification

All template examples were run through a real RFC 6570 expander (`url-template` v2) across the edge cases: optional location, default/empty omission, boolean flags, array explode, reserved-char encoding, and correct leading-`?` handling. All pass.

## Follow-ups (not in this PR)

- Each app repo adds its `signage-app.json` per the spec (Weather is the suggested pilot).
- Standardize the clock app URL on `https://clock.srly.io/` (its content front matter currently records `http://`, so its index entry is `http`).
- Build the store's generic config renderer that consumes `settings` + `launch`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)