### PR TITLE
Clock: use https app URL

### DIFF
--- a/content/clock/digital/index.html
+++ b/content/clock/digital/index.html
@@ -7,7 +7,7 @@ bodyclass: product
 appconfig: true
 weight: 1
 app:
-  url: http://clock.srly.io
+  url: https://clock.srly.io/
   image: app-clock-digital.jpg
 links:
   support: https://github.com/Screenly-Labs/clock-app/issues


### PR DESCRIPTION
The digital clock's `app.url` was `http://clock.srly.io`, which surfaced as an
`http://` manifest pointer in the generated `/manifest.json` while every other
app is `https`. Standardise the clock on `https://clock.srly.io/`.

Split out of #29 (merged before this fix landed on the branch). Verified with a
local `hugo` build that the clock entry in `/manifest.json` now reads
`https://clock.srly.io/.well-known/signage-app.json`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)