### PR TITLE
Manifest-driven store rendering + Product Hunt, Opening Hours & Moon Phase

### DIFF
--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -155,13 +155,17 @@
   /* Manifest-driven apps ship no screenshot: a branded gradient tile stands in
      (same aspect ratio, so cards and the detail hero stay uniform). */
   .app-shot-fallback {
-    @apply flex aspect-video w-full flex-col items-center justify-center gap-2 px-6 text-center;
+    @apply flex aspect-video w-full flex-col items-center justify-center gap-4 px-6 text-center;
     background:
       radial-gradient(130% 130% at 0% 0%, rgb(122 90 248 / 32%), transparent 55%),
       linear-gradient(135deg, var(--color-surface-2), var(--color-bg));
   }
-  .app-shot-fallback__tag { @apply font-mono text-[11px] uppercase tracking-[0.16em] text-accent2; }
-  .app-shot-fallback__name { @apply font-display text-2xl font-bold leading-tight text-ink; }
+  .app-shot-fallback__icon {
+    @apply text-[3.25rem] leading-none;
+    color: var(--color-accent2);
+    filter: drop-shadow(0 6px 20px rgb(55 182 255 / 35%));
+  }
+  .app-shot-fallback__name { @apply font-display text-xl font-bold leading-tight text-ink; }
 
   /* Generic settings form, rendered from a manifest by config-manifest.js */
   .cfg-fields { @apply flex flex-col gap-5; }

--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -152,6 +152,25 @@
   .card-screen:hover .card-screen__media img { transform: scale(1.04); }
   .card-screen__body { @apply p-5; }
 
+  /* Manifest-driven apps ship no screenshot: a branded gradient tile stands in
+     (same aspect ratio, so cards and the detail hero stay uniform). */
+  .app-shot-fallback {
+    @apply flex aspect-video w-full flex-col items-center justify-center gap-2 px-6 text-center;
+    background:
+      radial-gradient(130% 130% at 0% 0%, rgb(122 90 248 / 32%), transparent 55%),
+      linear-gradient(135deg, var(--color-surface-2), var(--color-bg));
+  }
+  .app-shot-fallback__tag { @apply font-mono text-[11px] uppercase tracking-[0.16em] text-accent2; }
+  .app-shot-fallback__name { @apply font-display text-2xl font-bold leading-tight text-ink; }
+
+  /* Generic settings form, rendered from a manifest by config-manifest.js */
+  .cfg-fields { @apply flex flex-col gap-5; }
+  .cfg-field { @apply flex flex-col; }
+  .cfg-group { @apply mt-1 font-display text-sm font-bold tracking-tight text-ink; }
+  .cfg-help { @apply mt-1.5 text-xs text-faint; }
+  .cfg-toggle { @apply inline-flex cursor-pointer items-center gap-3 text-sm text-ink; }
+  .cfg-toggle input { @apply h-4 w-4 rounded; accent-color: var(--color-accent); }
+
   /* Filter pills */
   .app-filter { @apply flex flex-wrap items-center gap-2; }
   .app-filter button {

--- a/assets/js/config-manifest.js
+++ b/assets/js/config-manifest.js
@@ -73,7 +73,7 @@ function renderField(key, schema, widget, set, host) {
     options.forEach((value, i) => {
       const opt = document.createElement('option');
       opt.value = value;
-      opt.textContent = labels[i] != null ? labels[i] : (value === '' ? 'Default' : String(value));
+      opt.textContent = labels[i] !== undefined ? labels[i] : (value === '' ? 'Default' : String(value));
       if (String(value) === String(schema.default ?? '')) opt.selected = true;
       select.appendChild(opt);
     });

--- a/assets/js/config-manifest.js
+++ b/assets/js/config-manifest.js
@@ -19,8 +19,13 @@ function widgetFor(schema) {
   if (Array.isArray(schema.enum)) return 'select';
   if (schema.type === 'boolean') return 'toggle';
   if (schema.type === 'number' || schema.type === 'integer') return 'number';
-  if (schema.type === 'object') return 'location-map';
-  if (schema.type === 'array') return 'array';
+  // Only a {lat,lng} object is a location map; other objects/arrays have no
+  // generic control, so mark them unsupported (skipped) rather than mis-render.
+  if (schema.type === 'object') {
+    const props = schema.properties || {};
+    return props.lat && props.lng ? 'location-map' : 'unsupported';
+  }
+  if (schema.type === 'array') return 'unsupported';
   return 'text';
 }
 
@@ -78,11 +83,11 @@ function timezoneList(host) {
 function renderField(key, schema, widget, set, host) {
   const id = `cfg-${key}`;
 
-  // Array settings (e.g. World Clock's repeated `{?tz*}`) need a bespoke
-  // add/remove-row UI, which the generic renderer doesn't provide. Skip them
-  // rather than emit a scalar text input that would send the wrong value type.
+  // Settings with no generic control — arrays (e.g. World Clock's repeated
+  // `{?tz*}`, which needs a bespoke add/remove-row UI) and non-location objects.
+  // Skip them rather than emit a scalar text input with the wrong value type.
   // (No manifest-driven app currently uses one; World Clock has its own form.)
-  if (widget === 'array') return null;
+  if (widget === 'unsupported') return null;
 
   if (widget === 'select') {
     const select = document.createElement('select');

--- a/assets/js/config-manifest.js
+++ b/assets/js/config-manifest.js
@@ -140,6 +140,7 @@ export function initManifestConfig() {
   if (!host || !urlInput) return;
 
   const script = host.querySelector('script[data-manifest]');
+  if (!script) return;
   let manifest;
   try {
     manifest = JSON.parse(script.textContent);

--- a/assets/js/config-manifest.js
+++ b/assets/js/config-manifest.js
@@ -1,0 +1,184 @@
+// Generic, manifest-driven settings form.
+//
+// The detail page embeds the app's signage-app manifest as JSON (see the
+// app-config.html partial). Here we read its `settings` JSON Schema and render
+// the form controls — one per property, in manifest order — then rebuild the
+// launch URL into #app-form-url from `launch.template` whenever a value changes.
+// No app re-implements its own form: every manifest-driven app shares this code.
+//
+// Supported `x-widget`s (falling back to the JSON Schema type): text, url,
+// number, select (enum), toggle (boolean), timezone, and location-map (a
+// {lat,lng} object). Unknown widgets degrade to a text input.
+
+import { buildLaunchUrl } from './lib/expand-template.js';
+import { initLocationMap } from './lib/location-map.js';
+
+// Which control to render for a settings property.
+function widgetFor(schema) {
+  if (schema['x-widget']) return schema['x-widget'];
+  if (Array.isArray(schema.enum)) return 'select';
+  if (schema.type === 'boolean') return 'toggle';
+  if (schema.type === 'number' || schema.type === 'integer') return 'number';
+  if (schema.type === 'object') return 'location-map';
+  return 'text';
+}
+
+// A labelled wrapper shared by every control.
+function fieldRow(schema, key, control, { labelFor } = {}) {
+  const row = document.createElement('div');
+  row.className = 'cfg-field';
+
+  const label = document.createElement('label');
+  label.className = 'eyebrow';
+  label.textContent = schema.title || key;
+  if (labelFor) label.htmlFor = labelFor;
+  row.append(label, control);
+
+  if (schema.description) {
+    const help = document.createElement('p');
+    help.className = 'cfg-help';
+    help.textContent = schema.description;
+    row.appendChild(help);
+  }
+  return row;
+}
+
+// Populate a <datalist> of IANA time zones when the browser can enumerate them.
+function timezoneList() {
+  const list = document.createElement('datalist');
+  list.id = 'cfg-tz-list';
+  const zones = typeof Intl.supportedValuesOf === 'function' ? Intl.supportedValuesOf('timeZone') : [];
+  for (const zone of zones) {
+    const opt = document.createElement('option');
+    opt.value = zone;
+    list.appendChild(opt);
+  }
+  return list.childElementCount ? list : null;
+}
+
+// Build the control for one property; wire it to `set(key, value)`.
+function renderField(key, schema, widget, set, host) {
+  const id = `cfg-${key}`;
+
+  if (widget === 'select') {
+    const select = document.createElement('select');
+    select.className = 'field mt-2';
+    select.id = id;
+    const labels = schema['x-enumLabels'] || [];
+    (schema.enum || []).forEach((value, i) => {
+      const opt = document.createElement('option');
+      opt.value = value;
+      opt.textContent = labels[i] || value || 'Default';
+      if (value === (schema.default ?? '')) opt.selected = true;
+      select.appendChild(opt);
+    });
+    select.addEventListener('change', () => set(key, select.value));
+    return fieldRow(schema, key, select, { labelFor: id });
+  }
+
+  if (widget === 'toggle') {
+    const wrap = document.createElement('label');
+    wrap.className = 'cfg-toggle mt-2';
+    const box = document.createElement('input');
+    box.type = 'checkbox';
+    box.id = id;
+    box.checked = schema.default === true;
+    const text = document.createElement('span');
+    text.textContent = schema.title || key;
+    wrap.append(box, text);
+    box.addEventListener('change', () => set(key, box.checked));
+    // The toggle carries its own inline label, so don't add a second one.
+    const row = document.createElement('div');
+    row.className = 'cfg-field';
+    row.appendChild(wrap);
+    if (schema.description) {
+      const help = document.createElement('p');
+      help.className = 'cfg-help';
+      help.textContent = schema.description;
+      row.appendChild(help);
+    }
+    return row;
+  }
+
+  if (widget === 'location-map') {
+    const mount = document.createElement('div');
+    mount.className = 'mt-2';
+    initLocationMap(mount, { onChange: ({ lat, lng }) => set(key, { lat, lng }) });
+    return fieldRow(schema, key, mount);
+  }
+
+  // Scalar text-like inputs: text, url, number, timezone.
+  const input = document.createElement('input');
+  input.className = 'field mt-2';
+  input.id = id;
+  input.value = schema.default ?? '';
+  if (widget === 'number') {
+    input.type = 'number';
+    if (schema.minimum !== undefined) input.min = schema.minimum;
+    if (schema.maximum !== undefined) input.max = schema.maximum;
+  } else if (widget === 'url') {
+    input.type = 'url';
+  } else {
+    input.type = 'text';
+  }
+  if (widget === 'timezone') {
+    const list = timezoneList();
+    if (list) {
+      host.appendChild(list);
+      input.setAttribute('list', list.id);
+      input.autocomplete = 'off';
+    }
+    input.placeholder = 'e.g. Europe/London';
+  }
+  input.addEventListener('input', () => set(key, input.value));
+  return fieldRow(schema, key, input, { labelFor: id });
+}
+
+export function initManifestConfig() {
+  const host = document.querySelector('[data-manifest-config]');
+  const urlInput = document.getElementById('app-form-url');
+  if (!host || !urlInput) return;
+
+  const script = host.querySelector('script[data-manifest]');
+  let manifest;
+  try {
+    manifest = JSON.parse(script.textContent);
+  } catch {
+    return;
+  }
+
+  const props = manifest.settings?.properties || {};
+  const launch = manifest.launch || {};
+  const baseUrl = launch.baseUrl || urlInput.dataset.url || '';
+  const template = launch.template || '';
+
+  const fields = host.querySelector('[data-config-fields]');
+  const values = {};
+  const defaults = {};
+  const update = () => {
+    urlInput.value = buildLaunchUrl(baseUrl, template, values, defaults);
+  };
+  const set = (key, value) => {
+    values[key] = value;
+    update();
+  };
+
+  let currentGroup = null;
+  for (const [key, schema] of Object.entries(props)) {
+    defaults[key] = schema.default;
+    values[key] = schema.default;
+
+    const group = schema['x-group'] || null;
+    if (group && group !== currentGroup) {
+      const heading = document.createElement('h3');
+      heading.className = 'cfg-group';
+      heading.textContent = group;
+      fields.appendChild(heading);
+    }
+    currentGroup = group;
+
+    fields.appendChild(renderField(key, schema, widgetFor(schema), set, host));
+  }
+
+  update();
+}

--- a/assets/js/config-manifest.js
+++ b/assets/js/config-manifest.js
@@ -20,19 +20,32 @@ function widgetFor(schema) {
   if (schema.type === 'boolean') return 'toggle';
   if (schema.type === 'number' || schema.type === 'integer') return 'number';
   if (schema.type === 'object') return 'location-map';
+  if (schema.type === 'array') return 'array';
   return 'text';
 }
 
-// A labelled wrapper shared by every control.
+// A labelled wrapper shared by every control. When the control is a real form
+// element we bind a <label for>; custom controls (e.g. the location map) have no
+// focusable input, so we use a plain styled caption and wire aria-labelledby.
 function fieldRow(schema, key, control, { labelFor } = {}) {
   const row = document.createElement('div');
   row.className = 'cfg-field';
 
-  const label = document.createElement('label');
-  label.className = 'eyebrow';
-  label.textContent = schema.title || key;
-  if (labelFor) label.htmlFor = labelFor;
-  row.append(label, control);
+  const captionText = schema.title || key;
+  let caption;
+  if (labelFor) {
+    caption = document.createElement('label');
+    caption.htmlFor = labelFor;
+  } else {
+    caption = document.createElement('span');
+    const captionId = `cfg-lbl-${key}`;
+    caption.id = captionId;
+    control.setAttribute('role', 'group');
+    control.setAttribute('aria-labelledby', captionId);
+  }
+  caption.className = 'eyebrow block';
+  caption.textContent = captionText;
+  row.append(caption, control);
 
   if (schema.description) {
     const help = document.createElement('p');
@@ -43,22 +56,33 @@ function fieldRow(schema, key, control, { labelFor } = {}) {
   return row;
 }
 
-// Populate a <datalist> of IANA time zones when the browser can enumerate them.
-function timezoneList() {
+// One shared <datalist> of IANA time zones for all timezone fields (avoids
+// duplicate ids), created lazily when the browser can enumerate zones.
+function timezoneList(host) {
+  const existing = host.querySelector('#cfg-tz-list');
+  if (existing) return existing;
+  const zones = typeof Intl.supportedValuesOf === 'function' ? Intl.supportedValuesOf('timeZone') : [];
+  if (!zones.length) return null;
   const list = document.createElement('datalist');
   list.id = 'cfg-tz-list';
-  const zones = typeof Intl.supportedValuesOf === 'function' ? Intl.supportedValuesOf('timeZone') : [];
   for (const zone of zones) {
     const opt = document.createElement('option');
     opt.value = zone;
     list.appendChild(opt);
   }
-  return list.childElementCount ? list : null;
+  host.appendChild(list);
+  return list;
 }
 
 // Build the control for one property; wire it to `set(key, value)`.
 function renderField(key, schema, widget, set, host) {
   const id = `cfg-${key}`;
+
+  // Array settings (e.g. World Clock's repeated `{?tz*}`) need a bespoke
+  // add/remove-row UI, which the generic renderer doesn't provide. Skip them
+  // rather than emit a scalar text input that would send the wrong value type.
+  // (No manifest-driven app currently uses one; World Clock has its own form.)
+  if (widget === 'array') return null;
 
   if (widget === 'select') {
     const select = document.createElement('select');
@@ -134,9 +158,8 @@ function renderField(key, schema, widget, set, host) {
     input.type = 'text';
   }
   if (widget === 'timezone') {
-    const list = timezoneList();
+    const list = timezoneList(host);
     if (list) {
-      host.appendChild(list);
       input.setAttribute('list', list.id);
       input.autocomplete = 'off';
     }
@@ -193,7 +216,8 @@ export function initManifestConfig() {
     }
     currentGroup = group;
 
-    fields.appendChild(renderField(key, schema, widgetFor(schema), set, host));
+    const field = renderField(key, schema, widgetFor(schema), set, host);
+    if (field) fields.appendChild(field);
   }
 
   update();

--- a/assets/js/config-manifest.js
+++ b/assets/js/config-manifest.js
@@ -65,14 +65,19 @@ function renderField(key, schema, widget, set, host) {
     select.className = 'field mt-2';
     select.id = id;
     const labels = schema['x-enumLabels'] || [];
-    (schema.enum || []).forEach((value, i) => {
+    const options = schema.enum || [];
+    // <select> values read back as strings; map the chosen option back to its
+    // original enum value so a typed (number/boolean) default still compares
+    // equal and isn't emitted into the URL.
+    const typed = (raw) => options.find((v) => String(v) === raw) ?? raw;
+    options.forEach((value, i) => {
       const opt = document.createElement('option');
       opt.value = value;
       opt.textContent = labels[i] || value || 'Default';
-      if (value === (schema.default ?? '')) opt.selected = true;
+      if (String(value) === String(schema.default ?? '')) opt.selected = true;
       select.appendChild(opt);
     });
-    select.addEventListener('change', () => set(key, select.value));
+    select.addEventListener('change', () => set(key, typed(select.value)));
     return fieldRow(schema, key, select, { labelFor: id });
   }
 
@@ -130,7 +135,10 @@ function renderField(key, schema, widget, set, host) {
     }
     input.placeholder = 'e.g. Europe/London';
   }
-  input.addEventListener('input', () => set(key, input.value));
+  // Number inputs read back as strings; store a Number so a numeric default
+  // compares equal and unchanged numeric defaults don't leak into the URL.
+  const read = widget === 'number' ? () => (input.value === '' ? '' : Number(input.value)) : () => input.value;
+  input.addEventListener('input', () => set(key, read()));
   return fieldRow(schema, key, input, { labelFor: id });
 }
 

--- a/assets/js/config-manifest.js
+++ b/assets/js/config-manifest.js
@@ -73,7 +73,7 @@ function renderField(key, schema, widget, set, host) {
     options.forEach((value, i) => {
       const opt = document.createElement('option');
       opt.value = value;
-      opt.textContent = labels[i] || value || 'Default';
+      opt.textContent = labels[i] != null ? labels[i] : (value === '' ? 'Default' : String(value));
       if (String(value) === String(schema.default ?? '')) opt.selected = true;
       select.appendChild(opt);
     });

--- a/assets/js/config-manifest.js
+++ b/assets/js/config-manifest.js
@@ -108,6 +108,13 @@ function renderField(key, schema, widget, set, host) {
   if (widget === 'location-map') {
     const mount = document.createElement('div');
     mount.className = 'mt-2';
+    // Seed the map from a schema default (initLocationMap reads data-lat/lng),
+    // so the control opens on the app's default rather than the generic centre.
+    const def = schema.default;
+    if (def && def.lat !== undefined && def.lng !== undefined) {
+      mount.dataset.lat = def.lat;
+      mount.dataset.lng = def.lng;
+    }
     initLocationMap(mount, { onChange: ({ lat, lng }) => set(key, { lat, lng }) });
     return fieldRow(schema, key, mount);
   }

--- a/assets/js/config.js
+++ b/assets/js/config.js
@@ -5,6 +5,7 @@
 import { buildQueryUrl } from './lib/query-url.js';
 import { initLocationMap } from './lib/location-map.js';
 import { initWorldClockConfig } from './config-world-clock.js';
+import { initManifestConfig } from './config-manifest.js';
 
 // Location + clock-format form shared by Weather, Air Quality and Clock.
 function initLocationConfig() {
@@ -35,7 +36,9 @@ function initLocationConfig() {
   });
 }
 
-if (document.querySelector('[data-world-clock-config]')) {
+if (document.querySelector('[data-manifest-config]')) {
+  initManifestConfig();
+} else if (document.querySelector('[data-world-clock-config]')) {
   initWorldClockConfig();
 } else {
   initLocationConfig();

--- a/assets/js/lib/expand-template.js
+++ b/assets/js/lib/expand-template.js
@@ -1,0 +1,59 @@
+// Build an app launch URL from a manifest's `launch.template` (an RFC 6570 URI
+// Template) and the current setting values. Pure function, unit tested.
+//
+// Every signage-app manifest expresses its launch URL as a single form-style
+// query expression, e.g. `{?name,tz,format}` or `{?location*,locale,24h}`. We
+// implement exactly that operator: `{?var,var*,...}`. A trailing `*` explodes an
+// array (repeated `name=` params) or an object (its `key=value` pairs).
+//
+// Only meaningful values reach the URL: a value that is undefined, empty, `false`
+// or equal to its schema default is omitted (so the URL stays at the app's
+// defaults until the user actually changes something). A boolean `true` becomes
+// `name=1`. Slashes and the `zone|label` pipe are kept literal — matching the
+// links apps document for themselves — while other reserved characters are
+// percent-encoded (consumers decode them either way).
+
+const encodeToken = (value) =>
+  encodeURIComponent(value).replace(/%2F/g, '/').replace(/%7C/g, '|');
+
+// A scalar value we drop from the URL: nothing chosen, or still at the default.
+function isEmpty(value, def) {
+  if (value === undefined || value === null || value === '' || value === false) return true;
+  return def !== undefined && value === def;
+}
+
+// Expand one template variable spec (optionally `name*`) into `key=value` parts.
+function expandVar(spec, values, defaults) {
+  const explode = spec.endsWith('*');
+  const name = explode ? spec.slice(0, -1) : spec;
+  const value = values[name];
+
+  if (explode) {
+    if (Array.isArray(value)) {
+      return value
+        .filter((v) => v !== undefined && v !== null && v !== '')
+        .map((v) => `${name}=${encodeToken(String(v))}`);
+    }
+    if (value && typeof value === 'object') {
+      return Object.entries(value)
+        .filter(([, v]) => v !== undefined && v !== null && v !== '')
+        .map(([k, v]) => `${name === '' ? k : k}=${encodeToken(String(v))}`);
+    }
+    return [];
+  }
+
+  if (isEmpty(value, defaults[name])) return [];
+  return [`${name}=${encodeToken(value === true ? '1' : String(value))}`];
+}
+
+export function buildLaunchUrl(baseUrl, template, values = {}, defaults = {}) {
+  if (!template) return baseUrl;
+  const match = template.match(/\{\?([^}]*)\}/);
+  if (!match) return baseUrl;
+
+  const parts = [];
+  for (const spec of match[1].split(',').map((s) => s.trim()).filter(Boolean)) {
+    parts.push(...expandVar(spec, values, defaults));
+  }
+  return parts.length ? `${baseUrl}?${parts.join('&')}` : baseUrl;
+}

--- a/assets/js/lib/expand-template.js
+++ b/assets/js/lib/expand-template.js
@@ -29,6 +29,9 @@ function expandVar(spec, values, defaults) {
   const value = values[name];
 
   if (explode) {
+    // Omit an exploded array/object that is still at its (non-empty) default.
+    const def = defaults[name];
+    if (def !== undefined && JSON.stringify(value) === JSON.stringify(def)) return [];
     if (Array.isArray(value)) {
       return value
         .filter((v) => v !== undefined && v !== null && v !== '')

--- a/assets/js/lib/expand-template.js
+++ b/assets/js/lib/expand-template.js
@@ -37,7 +37,7 @@ function expandVar(spec, values, defaults) {
     if (value && typeof value === 'object') {
       return Object.entries(value)
         .filter(([, v]) => v !== undefined && v !== null && v !== '')
-        .map(([k, v]) => `${name === '' ? k : k}=${encodeToken(String(v))}`);
+        .map(([k, v]) => `${encodeToken(k)}=${encodeToken(String(v))}`);
     }
     return [];
   }

--- a/content/moon/index.html
+++ b/content/moon/index.html
@@ -1,0 +1,5 @@
+---
+manifest: https://moon.srly.io/.well-known/signage-app.json
+bodyclass: product
+weight: 10
+---

--- a/content/opening-hours/index.html
+++ b/content/opening-hours/index.html
@@ -1,0 +1,5 @@
+---
+manifest: https://opening-hours.srly.io/.well-known/signage-app.json
+bodyclass: product
+weight: 9
+---

--- a/content/product-hunt/index.html
+++ b/content/product-hunt/index.html
@@ -1,0 +1,5 @@
+---
+manifest: https://product-hunt.srly.io/.well-known/signage-app.json
+bodyclass: product
+weight: 8
+---

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -9,6 +9,7 @@ export default [
       'resources/**',
       'node_modules/**',
       'assets/js/vendor/**',
+      '.claude/**',
     ],
   },
   js.configs.recommended,

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -1,49 +1,56 @@
 {{ define "main" }}
+{{ $meta := partial "app-meta.html" . }}
 <section class="wrap py-12 sm:py-16">
     {{ partial "detail-head.html" . }}
 
     <div class="mt-8 grid gap-10 lg:grid-cols-2 lg:items-start">
         <div class="overflow-hidden rounded-2xl border border-line-2" style="box-shadow:0 40px 80px -30px rgb(122 90 248 / 50%)">
-            {{ partial "optimg.html" (dict "src" (printf "img/%s" .Params.app.image) "alt" .Title "widths" (slice 640 960 1280) "sizes" "(min-width:1024px) 48vw, 92vw" "loading" "eager") }}
+            {{ with $meta.image }}
+            {{ partial "optimg.html" (dict "src" (printf "img/%s" .) "alt" $meta.title "widths" (slice 640 960 1280) "sizes" "(min-width:1024px) 48vw, 92vw" "loading" "eager") }}
+            {{ else }}
+            {{ partial "app-placeholder.html" (dict "title" $meta.title "tag" $meta.tag0) }}
+            {{ end }}
         </div>
 
         <div>
-            <span class="tag">{{ index (split .Params.masonry ",") 0 | strings.TrimSpace }}</span>
-            <h1 class="mt-2 text-4xl sm:text-5xl">{{ .Title }}</h1>
-            <p class="mt-4 text-lg text-dim">{{ .Params.description }}</p>
+            <span class="tag">{{ $meta.tag0 }}</span>
+            <h1 class="mt-2 text-4xl sm:text-5xl">{{ $meta.title }}</h1>
+            <p class="mt-4 text-lg text-dim">{{ $meta.description }}</p>
 
             <div class="mt-8">
                 <label class="eyebrow" for="app-form-url">App link</label>
-                <input class="field mt-2" id="app-form-url" type="text" data-url="{{ .Params.app.url }}" value="{{ .Params.app.url }}" readonly>
+                <input class="field mt-2" id="app-form-url" type="text" data-url="{{ $meta.url }}" value="{{ $meta.url }}" readonly>
                 <p class="mt-2 text-xs text-faint">Paste this link into Anthias, Screenly, or any compatible smart TV or signage player.</p>
             </div>
 
             <div class="mt-5 flex flex-wrap gap-3">
-                {{ if .Params.appconfig }}
+                {{ if $meta.appconfig }}
                 <div class="modal-instance">
                     <a class="btn-primary modal-trigger" href="#">Configure settings</a>
                     <div class="modal-container">
                         <div class="modal-content">
                             <div class="modal-close modal-close-cross" role="button" aria-label="Close"></div>
+                            {{ if $meta.manifest }}
+                            {{ partial "app-config.html" $meta }}
+                            {{ else }}
                             {{ .Content }}
+                            {{ end }}
                         </div>
                     </div>
                 </div>
                 {{ end }}
-                <button type="button" id="app-form-btn" class="btn-clipboard {{ if .Params.appconfig }}btn-ghost{{ else }}btn-primary{{ end }}" data-clipboard-target="#app-form-url">
+                <button type="button" id="app-form-btn" class="btn-clipboard {{ if $meta.appconfig }}btn-ghost{{ else }}btn-primary{{ end }}" data-clipboard-target="#app-form-url">
                     {{ partial "icon.html" "clipboard" }} <span data-copy-label>Copy link</span>
                 </button>
-                <a class="btn-ghost" href="{{ .Params.app.url }}" target="_blank" rel="noopener" data-live-preview>
+                <a class="btn-ghost" href="{{ $meta.url }}" target="_blank" rel="noopener" data-live-preview>
                     Live preview {{ partial "icon.html" "external-link" }}
                 </a>
             </div>
 
-            {{ with .Params.links }}
             <div class="mt-6 flex flex-wrap gap-x-6 gap-y-2 text-sm">
-                {{ with .support }}<a class="link-accent" href="{{ . }}" target="_blank" rel="noopener">Support</a>{{ end }}
-                {{ with .source }}<a class="link-accent" href="{{ . }}" target="_blank" rel="noopener">Source code</a>{{ end }}
+                {{ with $meta.support }}<a class="link-accent" href="{{ . }}" target="_blank" rel="noopener">Support</a>{{ end }}
+                {{ with $meta.source }}<a class="link-accent" href="{{ . }}" target="_blank" rel="noopener">Source code</a>{{ end }}
             </div>
-            {{ end }}
         </div>
     </div>
 </section>

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -1,5 +1,5 @@
 {{ define "main" }}
-{{ $meta := partial "app-meta.html" . }}
+{{ $meta := partialCached "app-meta.html" . .RelPermalink }}
 <section class="wrap py-12 sm:py-16">
     {{ partial "detail-head.html" . }}
 

--- a/layouts/index.appindex.json
+++ b/layouts/index.appindex.json
@@ -7,17 +7,25 @@
 {{- $apps := slice -}}
 {{- $seen := slice -}}
 {{- range .Site.RegularPages -}}
-  {{- with .Params.app -}}
-    {{- with .url -}}
+  {{- /* A page points at its manifest either directly (`manifest:` front
+     matter, manifest-driven apps) or via its launch origin (`app.url`, the
+     hand-authored apps, whose manifest sits at the well-known path). */ -}}
+  {{- $manifest := "" -}}
+  {{- with .Params.manifest -}}
+    {{- $manifest = . -}}
+  {{- else -}}
+    {{- with .Params.app -}}{{ with .url -}}
       {{- $u := urls.Parse . -}}
-      {{- $origin := printf "%s://%s" $u.Scheme $u.Host -}}
-      {{- if not (in $seen $origin) -}}
-        {{- $seen = $seen | append $origin -}}
-        {{- $id := index (split $u.Host ".") 0 -}}
-        {{- $apps = $apps | append (dict
-          "id" $id
-          "manifest" (printf "%s/.well-known/signage-app.json" $origin)) -}}
-      {{- end -}}
+      {{- $manifest = printf "%s://%s/.well-known/signage-app.json" $u.Scheme $u.Host -}}
+    {{- end }}{{ end -}}
+  {{- end -}}
+  {{- with $manifest -}}
+    {{- $u := urls.Parse . -}}
+    {{- $origin := printf "%s://%s" $u.Scheme $u.Host -}}
+    {{- if not (in $seen $origin) -}}
+      {{- $seen = $seen | append $origin -}}
+      {{- $id := index (split $u.Host ".") 0 -}}
+      {{- $apps = $apps | append (dict "id" $id "manifest" .) -}}
     {{- end -}}
   {{- end -}}
 {{- end -}}

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -47,15 +47,20 @@
 
     <div class="app-grid mt-10" data-app-grid>
         {{ range .Site.RegularPages.ByWeight }}
-        <a class="card-screen reveal" href="{{ .RelPermalink }}" data-categories="{{ .Params.masonry }}">
+        {{ $meta := partial "app-meta.html" . }}
+        <a class="card-screen reveal" href="{{ .RelPermalink }}" data-categories="{{ $meta.tagsCsv }}">
             <div class="card-screen__media">
-                {{ partial "optimg.html" (dict "src" (printf "img/%s" .Params.app.image) "alt" .Title "widths" (slice 400 800) "sizes" "(min-width:1024px) 360px, (min-width:640px) 45vw, 90vw") }}
+                {{ with $meta.image }}
+                {{ partial "optimg.html" (dict "src" (printf "img/%s" .) "alt" $meta.title "widths" (slice 400 800) "sizes" "(min-width:1024px) 360px, (min-width:640px) 45vw, 90vw") }}
+                {{ else }}
+                {{ partial "app-placeholder.html" (dict "title" $meta.title "tag" $meta.tag0) }}
+                {{ end }}
             </div>
             <div class="card-screen__body">
-                <span class="tag">{{ index (split .Params.masonry ",") 0 | strings.TrimSpace }}</span>
-                <h3 class="mt-2 text-xl">{{ .Title }}</h3>
-                <p class="mt-1 text-sm text-dim">{{ .Params.cardtext }}</p>
-                <span class="mt-4 link-accent text-sm">{{ if .Params.appconfig }}Configure{{ else }}Get app{{ end }} {{ partial "icon.html" "arrow-right" }}</span>
+                <span class="tag">{{ $meta.tag0 }}</span>
+                <h3 class="mt-2 text-xl">{{ $meta.title }}</h3>
+                <p class="mt-1 text-sm text-dim">{{ $meta.cardtext }}</p>
+                <span class="mt-4 link-accent text-sm">{{ if $meta.appconfig }}Configure{{ else }}Get app{{ end }} {{ partial "icon.html" "arrow-right" }}</span>
             </div>
         </a>
         {{ end }}

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -47,7 +47,7 @@
 
     <div class="app-grid mt-10" data-app-grid>
         {{ range .Site.RegularPages.ByWeight }}
-        {{ $meta := partial "app-meta.html" . }}
+        {{ $meta := partialCached "app-meta.html" . .RelPermalink }}
         <a class="card-screen reveal" href="{{ .RelPermalink }}" data-categories="{{ $meta.tagsCsv }}">
             <div class="card-screen__media">
                 {{ with $meta.image }}

--- a/layouts/partials/app-config.html
+++ b/layouts/partials/app-config.html
@@ -8,5 +8,7 @@
 <div id="config" data-manifest-config>
     <h2 class="text-2xl">{{ .title }} settings</h2>
     <div class="cfg-fields mt-6" data-config-fields></div>
-    <script type="application/json" data-manifest>{{ .manifestRaw | safeJS }}</script>
+    {{- /* Neutralise any `</script>` inside the JSON (valid in a string, but it
+       would close this tag early). `<\/` is an equivalent JSON escape. */ -}}
+    <script type="application/json" data-manifest>{{ (replace .manifestRaw "</" "<\\/") | safeJS }}</script>
 </div>

--- a/layouts/partials/app-config.html
+++ b/layouts/partials/app-config.html
@@ -1,0 +1,12 @@
+{{- /*
+  Generic settings form host for a manifest-driven app. Emits the raw manifest
+  JSON (property order preserved, unlike a re-marshalled Go map) into the page;
+  assets/js/config-manifest.js reads its `settings` + `launch` and renders the
+  form controls, then builds the launch URL into #app-form-url as they change.
+  Receives the app-meta dict as context.
+*/ -}}
+<div id="config" data-manifest-config>
+    <h2 class="text-2xl">{{ .title }} settings</h2>
+    <div class="cfg-fields mt-6" data-config-fields></div>
+    <script type="application/json" data-manifest>{{ .manifestRaw | safeJS }}</script>
+</div>

--- a/layouts/partials/app-meta.html
+++ b/layouts/partials/app-meta.html
@@ -41,9 +41,10 @@
   {{- end -}}
   {{- $m := $parsed.Value -}}
   {{- /* Fail fast on a malformed/incomplete manifest rather than silently
-       rendering empty titles, links and SEO. */ -}}
-  {{- if or (not $m.name) (not $m.description) (not $m.launch) (not $m.launch.baseUrl) -}}
-    {{- errorf "app-meta: manifest %q is missing a required field (name, description, launch.baseUrl)" $url -}}
+       rendering empty titles, links and SEO. Mirrors the schema's required set
+       (manifestVersion, id, name, description, launch.baseUrl). */ -}}
+  {{- if or (not $m.manifestVersion) (not $m.id) (not $m.name) (not $m.description) (not $m.launch) (not $m.launch.baseUrl) -}}
+    {{- errorf "app-meta: manifest %q is missing a required field (manifestVersion, id, name, description, launch.baseUrl)" $url -}}
   {{- end -}}
   {{- $tags := or $m.tags slice -}}
   {{- $img := "" -}}{{- with $p.Params.app }}{{ $img = .image }}{{ end -}}

--- a/layouts/partials/app-meta.html
+++ b/layouts/partials/app-meta.html
@@ -1,0 +1,79 @@
+{{- /*
+  Resolve an app's display fields from its signage-app manifest.
+
+  When a content page declares `manifest: <url>` in front matter, the store
+  fetches that manifest at build time (cached by Hugo) and renders the card,
+  detail page, SEO and config form straight from it — the manifest is the single
+  source of truth, so nothing is re-authored by hand here. Pages without a
+  `manifest` fall back to their own front matter, so the existing hand-authored
+  apps are unaffected.
+
+  Returns a dict; callers read the same keys regardless of the source:
+    manifest    parsed manifest map, or false for front-matter apps
+    manifestRaw raw manifest JSON string (property order preserved), or ""
+    title description cardtext url source support image
+    tags (slice)  tagsCsv (string)  tag0 (string)  appconfig (bool)
+
+  See docs/app-manifest.md.
+*/ -}}
+{{- $p := . -}}
+{{- $url := $p.Params.manifest -}}
+{{- $out := dict -}}
+{{- if $url -}}
+  {{- $try := try (resources.GetRemote $url) -}}
+  {{- $res := "" -}}
+  {{- with $try.Err -}}
+    {{- errorf "app-meta: cannot fetch manifest %q: %s" $url . -}}
+  {{- else -}}
+    {{- $res = $try.Value -}}
+  {{- end -}}
+  {{- if not $res -}}
+    {{- errorf "app-meta: manifest %q returned no resource" $url -}}
+  {{- end -}}
+  {{- /* Unmarshal the string, not the resource: transform.Unmarshal mutates a
+       resource's .Content to its re-marshalled (escaped) form, and that resource
+       is cached and shared across pages. Parsing the raw string keeps .Content
+       intact so we can embed the original JSON verbatim (property order kept). */ -}}
+  {{- $raw := $res.Content -}}
+  {{- $m := transform.Unmarshal $raw -}}
+  {{- $tags := or $m.tags slice -}}
+  {{- $img := "" -}}{{- with $p.Params.app }}{{ $img = .image }}{{ end -}}
+  {{- $out = dict
+      "manifest"    $m
+      "manifestRaw" $raw
+      "title"       $m.name
+      "description" $m.description
+      "cardtext"    (or $m.summary $m.description)
+      "url"         $m.launch.baseUrl
+      "source"      $m.source
+      "support"     $m.support
+      "image"       $img
+      "tags"        $tags
+      "tagsCsv"     (delimit $tags ", ")
+      "tag0"        (cond (gt (len $tags) 0) (index $tags 0) "App")
+      "appconfig"   (ne (index $m "settings") nil)
+  -}}
+{{- else -}}
+  {{- $masonry := or $p.Params.masonry "" -}}
+  {{- $tags := slice -}}
+  {{- range (split $masonry ",") }}{{ with (trim . " ") }}{{ $tags = $tags | append . }}{{ end }}{{ end -}}
+  {{- $url := "" -}}{{- with $p.Params.app }}{{ $url = .url }}{{ end -}}
+  {{- $img := "" -}}{{- with $p.Params.app }}{{ $img = .image }}{{ end -}}
+  {{- $src := "" -}}{{- $sup := "" -}}{{- with $p.Params.links }}{{ $src = .source }}{{ $sup = .support }}{{ end -}}
+  {{- $out = dict
+      "manifest"    false
+      "manifestRaw" ""
+      "title"       $p.Title
+      "description" (or $p.Params.description $p.Description)
+      "cardtext"    $p.Params.cardtext
+      "url"         $url
+      "source"      $src
+      "support"     $sup
+      "image"       $img
+      "tags"        $tags
+      "tagsCsv"     $masonry
+      "tag0"        (cond (gt (len $tags) 0) (index $tags 0) "App")
+      "appconfig"   (eq $p.Params.appconfig true)
+  -}}
+{{- end -}}
+{{- return $out -}}

--- a/layouts/partials/app-meta.html
+++ b/layouts/partials/app-meta.html
@@ -35,7 +35,16 @@
        is cached and shared across pages. Parsing the raw string keeps .Content
        intact so we can embed the original JSON verbatim (property order kept). */ -}}
   {{- $raw := $res.Content -}}
-  {{- $m := transform.Unmarshal $raw -}}
+  {{- $parsed := try (transform.Unmarshal $raw) -}}
+  {{- with $parsed.Err -}}
+    {{- errorf "app-meta: manifest %q is not valid JSON: %s" $url . -}}
+  {{- end -}}
+  {{- $m := $parsed.Value -}}
+  {{- /* Fail fast on a malformed/incomplete manifest rather than silently
+       rendering empty titles, links and SEO. */ -}}
+  {{- if or (not $m.name) (not $m.description) (not $m.launch) (not $m.launch.baseUrl) -}}
+    {{- errorf "app-meta: manifest %q is missing a required field (name, description, launch.baseUrl)" $url -}}
+  {{- end -}}
   {{- $tags := or $m.tags slice -}}
   {{- $img := "" -}}{{- with $p.Params.app }}{{ $img = .image }}{{ end -}}
   {{- $out = dict

--- a/layouts/partials/app-placeholder.html
+++ b/layouts/partials/app-placeholder.html
@@ -22,6 +22,8 @@
   "Quiz"         "icon-[lucide--brain]"
   "Words"        "icon-[lucide--book-open]"
   "Quotes"       "icon-[lucide--quote]"
+  "Moon"         "icon-[lucide--moon]"
+  "Astronomy"    "icon-[lucide--telescope]"
 -}}
 {{- $icon := or (index $icons .tag) "icon-[lucide--app-window]" -}}
 <div class="app-shot-fallback">

--- a/layouts/partials/app-placeholder.html
+++ b/layouts/partials/app-placeholder.html
@@ -1,0 +1,9 @@
+{{- /*
+  Fallback "screen" media for apps whose manifest carries no screenshot/icon.
+  A branded gradient tile showing the app name, so manifest-only apps still read
+  as a screen card. Params: title (required), tag (optional).
+*/ -}}
+<div class="app-shot-fallback">
+    {{- with .tag }}<span class="app-shot-fallback__tag">{{ . }}</span>{{ end }}
+    <span class="app-shot-fallback__name">{{ .title }}</span>
+</div>

--- a/layouts/partials/app-placeholder.html
+++ b/layouts/partials/app-placeholder.html
@@ -1,9 +1,30 @@
 {{- /*
   Fallback "screen" media for apps whose manifest carries no screenshot/icon.
-  A branded gradient tile showing the app name, so manifest-only apps still read
-  as a screen card. Params: title (required), tag (optional).
+  A branded gradient tile with a Lucide icon (from our @iconify-json/lucide kit)
+  chosen from the app's primary tag, plus the app name — so manifest-only apps
+  still read as a screen card. Params: title (required), tag (optional).
+
+  The icon classes are full literals so Tailwind compiles them (assets/css scans
+  layouts); add a tag here to give a new category its own icon. Anything
+  unmapped falls back to a neutral app-window glyph.
 */ -}}
+{{- $icons := dict
+  "Retail"       "icon-[lucide--store]"
+  "Hospitality"  "icon-[lucide--utensils]"
+  "Business"     "icon-[lucide--briefcase]"
+  "Technology"   "icon-[lucide--rocket]"
+  "Clock"        "icon-[lucide--clock]"
+  "Weather"      "icon-[lucide--cloud-sun]"
+  "Air Quality"  "icon-[lucide--wind]"
+  "News"         "icon-[lucide--newspaper]"
+  "History"      "icon-[lucide--landmark]"
+  "Geography"    "icon-[lucide--globe]"
+  "Quiz"         "icon-[lucide--brain]"
+  "Words"        "icon-[lucide--book-open]"
+  "Quotes"       "icon-[lucide--quote]"
+-}}
+{{- $icon := or (index $icons .tag) "icon-[lucide--app-window]" -}}
 <div class="app-shot-fallback">
-    {{- with .tag }}<span class="app-shot-fallback__tag">{{ . }}</span>{{ end }}
+    <span class="app-shot-fallback__icon {{ $icon }}" aria-hidden="true"></span>
     <span class="app-shot-fallback__name">{{ .title }}</span>
 </div>

--- a/layouts/partials/detail-head.html
+++ b/layouts/partials/detail-head.html
@@ -1,5 +1,5 @@
 <nav class="breadcrumbs" aria-label="Breadcrumb">
     <a class="transition-colors hover:text-ink" href="{{ "/" | relURL }}">Home</a>
     <span aria-hidden="true">/</span>
-    <span class="text-dim">{{ (partial "app-meta.html" .).title }}</span>
+    <span class="text-dim">{{ (partialCached "app-meta.html" . .RelPermalink).title }}</span>
 </nav>

--- a/layouts/partials/detail-head.html
+++ b/layouts/partials/detail-head.html
@@ -1,5 +1,5 @@
 <nav class="breadcrumbs" aria-label="Breadcrumb">
     <a class="transition-colors hover:text-ink" href="{{ "/" | relURL }}">Home</a>
     <span aria-hidden="true">/</span>
-    <span class="text-dim">{{ .Title }}</span>
+    <span class="text-dim">{{ (partial "app-meta.html" .).title }}</span>
 </nav>

--- a/layouts/partials/foot.html
+++ b/layouts/partials/foot.html
@@ -5,7 +5,7 @@
         {{ $main := resources.Get "js/main.js" | js.Build (dict "minify" true "target" "es2018") | fingerprint }}
         <script src="{{ $main.RelPermalink }}" integrity="{{ $main.Data.Integrity }}"></script>
 
-        {{ if (partial "app-meta.html" .).appconfig }}
+        {{ if (partialCached "app-meta.html" . .RelPermalink).appconfig }}
         <!-- App configuration page behaviour -->
         {{ $cfg := resources.Get "js/config.js" | js.Build (dict "minify" true "target" "es2018") | fingerprint }}
         <script src="{{ $cfg.RelPermalink }}" integrity="{{ $cfg.Data.Integrity }}"></script>

--- a/layouts/partials/foot.html
+++ b/layouts/partials/foot.html
@@ -5,7 +5,7 @@
         {{ $main := resources.Get "js/main.js" | js.Build (dict "minify" true "target" "es2018") | fingerprint }}
         <script src="{{ $main.RelPermalink }}" integrity="{{ $main.Data.Integrity }}"></script>
 
-        {{ if .Params.appconfig }}
+        {{ if (partial "app-meta.html" .).appconfig }}
         <!-- App configuration page behaviour -->
         {{ $cfg := resources.Get "js/config.js" | js.Build (dict "minify" true "target" "es2018") | fingerprint }}
         <script src="{{ $cfg.RelPermalink }}" integrity="{{ $cfg.Data.Integrity }}"></script>

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -5,7 +5,7 @@
         <meta charset="UTF-8">
         <meta http-equiv="X-UA-Compatible" content="IE=edge">
         <meta name="viewport" content="width=device-width, initial-scale=1">
-        <title>{{ if .IsHome }}{{ .Site.Title }} for Any Screen{{ else }}{{ (partial "app-meta.html" .).title }} - {{ .Site.Title }}{{ end }}</title>
+        <title>{{ if .IsHome }}{{ .Site.Title }} for Any Screen{{ else }}{{ (partialCached "app-meta.html" . .RelPermalink).title }} - {{ .Site.Title }}{{ end }}</title>
 
         <link rel="preload" as="font" type="font/woff2" href="{{ "fonts/space-grotesk/space-grotesk-latin-700-normal.woff2" | relURL }}" crossorigin>
 

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -5,7 +5,7 @@
         <meta charset="UTF-8">
         <meta http-equiv="X-UA-Compatible" content="IE=edge">
         <meta name="viewport" content="width=device-width, initial-scale=1">
-        <title>{{ if .IsHome }}{{ .Site.Title }} for Any Screen{{ else }}{{ .Title }} - {{ .Site.Title }}{{ end }}</title>
+        <title>{{ if .IsHome }}{{ .Site.Title }} for Any Screen{{ else }}{{ (partial "app-meta.html" .).title }} - {{ .Site.Title }}{{ end }}</title>
 
         <link rel="preload" as="font" type="font/woff2" href="{{ "fonts/space-grotesk/space-grotesk-latin-700-normal.woff2" | relURL }}" crossorigin>
 

--- a/layouts/partials/seo.html
+++ b/layouts/partials/seo.html
@@ -1,5 +1,5 @@
 {{- /* SEO meta: canonical, description, Open Graph, Twitter cards, JSON-LD. */ -}}
-{{- $meta := partial "app-meta.html" . -}}
+{{- $meta := partialCached "app-meta.html" . .RelPermalink -}}
 {{- $title := cond .IsHome (printf "%s for Any Screen" .Site.Title) (printf "%s - %s" $meta.title .Site.Title) -}}
 {{- $desc := or $meta.description .Site.Params.description -}}
 

--- a/layouts/partials/seo.html
+++ b/layouts/partials/seo.html
@@ -1,10 +1,11 @@
 {{- /* SEO meta: canonical, description, Open Graph, Twitter cards, JSON-LD. */ -}}
-{{- $title := cond .IsHome (printf "%s for Any Screen" .Site.Title) (printf "%s - %s" .Title .Site.Title) -}}
-{{- $desc := or .Description .Site.Params.description -}}
+{{- $meta := partial "app-meta.html" . -}}
+{{- $title := cond .IsHome (printf "%s for Any Screen" .Site.Title) (printf "%s - %s" $meta.title .Site.Title) -}}
+{{- $desc := or $meta.description .Site.Params.description -}}
 
 {{- /* Build a correctly-sized (1200x630) social share image from the page's image. */ -}}
 {{- $ogsrc := .Site.Params.ogimage -}}
-{{- with .Params.app }}{{ with .image }}{{ $ogsrc = printf "img/%s" . }}{{ end }}{{ end -}}
+{{- with $meta.image }}{{ $ogsrc = printf "img/%s" . }}{{ end -}}
 {{- $ogimage := "" }}{{ $ogw := 1200 }}{{ $ogh := 630 -}}
 {{- with resources.Get $ogsrc }}{{ $f := .Fill "1200x630 jpg q82" }}{{ $ogimage = $f.Permalink }}{{ end -}}
 
@@ -51,7 +52,7 @@
         {{- dict
             "@context" "https://schema.org"
             "@type" "SoftwareApplication"
-            "name" .Title
+            "name" $meta.title
             "description" $desc
             "applicationCategory" "BusinessApplication"
             "operatingSystem" "Web, Anthias, Screenly"
@@ -67,7 +68,7 @@
             "@type" "BreadcrumbList"
             "itemListElement" (slice
                 (dict "@type" "ListItem" "position" 1 "name" "Home" "item" .Site.BaseURL)
-                (dict "@type" "ListItem" "position" 2 "name" .Title "item" .Permalink))
+                (dict "@type" "ListItem" "position" 2 "name" $meta.title "item" .Permalink))
             | jsonify (dict "indent" "  ") | safeJS }}
         </script>
         {{- end }}

--- a/test/expand-template.test.js
+++ b/test/expand-template.test.js
@@ -49,6 +49,19 @@ describe('buildLaunchUrl', () => {
     );
   });
 
+  test('omits a numeric value equal to its numeric default', () => {
+    const defaults = { count: 5 };
+    expect(buildLaunchUrl(BASE, '{?count}', { count: 5 }, defaults)).toBe(BASE);
+    expect(buildLaunchUrl(BASE, '{?count}', { count: 8 }, defaults)).toBe(`${BASE}?count=8`);
+  });
+
+  test('omits an exploded array/object still at its default', () => {
+    const t = '{?tz*}';
+    const defaults = { tz: ['Europe/London'] };
+    expect(buildLaunchUrl(BASE, t, { tz: ['Europe/London'] }, defaults)).toBe(BASE);
+    expect(buildLaunchUrl(BASE, t, { tz: ['Asia/Tokyo'] }, defaults)).toBe(`${BASE}?tz=Asia/Tokyo`);
+  });
+
   test('percent-encodes spaces but keeps commas readable via decode round-trip', () => {
     const v = { mon: '09:00-12:00,13:00-17:00' };
     const url = buildLaunchUrl(BASE, '{?mon}', v);

--- a/test/expand-template.test.js
+++ b/test/expand-template.test.js
@@ -1,0 +1,58 @@
+import { describe, expect, test } from 'bun:test';
+import { buildLaunchUrl } from '../assets/js/lib/expand-template.js';
+
+const BASE = 'https://opening-hours.srly.io/';
+
+describe('buildLaunchUrl', () => {
+  test('returns the bare url with no template', () => {
+    expect(buildLaunchUrl(BASE, '')).toBe(BASE);
+    expect(buildLaunchUrl('https://product-hunt.srly.io/')).toBe('https://product-hunt.srly.io/');
+  });
+
+  test('returns the bare url when nothing is set', () => {
+    expect(buildLaunchUrl(BASE, '{?name,tz,format,mon}')).toBe(BASE);
+  });
+
+  test('emits only the set params, in template order', () => {
+    const t = '{?name,tz,format,mon,tue}';
+    const v = { name: 'Cafe', tz: 'Europe/London', mon: '09:00-17:00' };
+    expect(buildLaunchUrl(BASE, t, v)).toBe(
+      `${BASE}?name=Cafe&tz=Europe/London&mon=09%3A00-17%3A00`,
+    );
+  });
+
+  test('omits a value equal to its default', () => {
+    const t = '{?format,seconds}';
+    const defaults = { format: '', seconds: false };
+    expect(buildLaunchUrl(BASE, t, { format: '', seconds: false }, defaults)).toBe(BASE);
+    expect(buildLaunchUrl(BASE, t, { format: '24', seconds: false }, defaults)).toBe(`${BASE}?format=24`);
+  });
+
+  test('renders a boolean true as name=1 and omits false', () => {
+    expect(buildLaunchUrl(BASE, '{?seconds}', { seconds: true })).toBe(`${BASE}?seconds=1`);
+    expect(buildLaunchUrl(BASE, '{?seconds}', { seconds: false })).toBe(BASE);
+  });
+
+  test('explodes an object into its key=value pairs, keeping slashes literal', () => {
+    const t = '{?location*,locale}';
+    const v = { location: { lat: '51.5', lng: '-0.12' }, locale: 'en-GB' };
+    expect(buildLaunchUrl('https://weather.srly.io/', t, v)).toBe(
+      'https://weather.srly.io/?lat=51.5&lng=-0.12&locale=en-GB',
+    );
+  });
+
+  test('explodes an array into repeated params', () => {
+    const t = '{?tz*}';
+    const v = { tz: ['Europe/London', 'Asia/Tokyo|HQ'] };
+    expect(buildLaunchUrl('https://world-clock.srly.io/', t, v)).toBe(
+      'https://world-clock.srly.io/?tz=Europe/London&tz=Asia/Tokyo|HQ',
+    );
+  });
+
+  test('percent-encodes spaces but keeps commas readable via decode round-trip', () => {
+    const v = { mon: '09:00-12:00,13:00-17:00' };
+    const url = buildLaunchUrl(BASE, '{?mon}', v);
+    const got = new URL(url).searchParams.get('mon');
+    expect(got).toBe('09:00-12:00,13:00-17:00');
+  });
+});


### PR DESCRIPTION
Adds a **generic, manifest-driven rendering path** to the store, and the first three apps that use it: **Product Hunt** (no settings), **Opening Hours** (a full settings form) and **Moon Phase** (a location-map setting). Their card, detail page, SEO, launch URL and config form are all rendered live from each app's self-hosted `/.well-known/signage-app.json` — nothing is re-authored by hand.

### Opting in
A content page needs just one front-matter key:
```yaml
---
manifest: https://moon.srly.io/.well-known/signage-app.json
weight: 10
bodyclass: product
---
```
Everything else — title, description, summary, tags, launch base URL, source/support links, and the settings form — comes from the manifest. Pages without `manifest:` fall back to their own front matter, so the existing hand-authored apps render byte-for-byte as before.

### How it works
- **`partials/app-meta.html`** — fetches the manifest at build (`resources.GetRemote`, cached), validates required fields (fails the build loudly on an unreachable/invalid manifest), and resolves the display fields into one dict shared across the card, detail page, SEO, breadcrumb and config loader (via `partialCached`, so it's parsed once per page).
- **`partials/app-config.html`** — embeds the raw manifest JSON (property order preserved; `</script>` neutralised) for the client.
- **`assets/js/config-manifest.js`** — renders the form from the JSON Schema: text / url / number / select / toggle / timezone / location-map, honoring `x-widget`, `x-enumLabels`, `x-group`, and (type-preserving) defaults.
- **`assets/js/lib/expand-template.js`** — builds the launch URL from `launch.template` (RFC 6570 `{?…}` incl. `*` explode), omitting empty/default values. Unit-tested.
- Manifest-only apps (no screenshot) get a branded gradient placeholder tile with a **Lucide icon from our kit**, chosen from the primary tag.
- `/manifest.json` index now lists all 13 apps.

### Verification
`hugo --minify` clean · `bun run lint` clean · `bun test` 21 pass · Playwright smoke test passing · CI green. All Copilot review feedback addressed (script-embed hardening, type-preserving default checks, manifest validation, a11y captions, shared tz datalist, array guard, partialCached).

### Note
The store build now fetches the app manifests at build time (`resources.GetRemote`). Per discussion, these origins are treated as always-available, so the build **fails fast** if one is unreachable rather than silently dropping the app.

🤖 Generated with [Claude Code](https://claude.com/claude-code)