### PR TITLE
Add playful tagline to hero eyebrow

### DIFF
--- a/layouts/index.html
+++ b/layouts/index.html
@@ -3,7 +3,7 @@
 <section class="hero">
     <div class="wrap grid items-center gap-12 py-16 sm:py-24 lg:grid-cols-2">
         <div>
-            <p class="eyebrow">// Free digital signage apps</p>
+            <p class="eyebrow">// Probably the world's biggest free digital signage app store</p>
             <h1 class="mt-5 text-5xl leading-[0.95] sm:text-6xl xl:text-7xl">
                 Display anything.<br><span class="text-grad">On every screen.</span>
             </h1>


### PR DESCRIPTION
## Summary
Updates the homepage hero eyebrow to a playful, Carlsberg-style tagline:

> // Probably the world's biggest free digital signage app store

## Details
- Replaces the previous `// Free digital signage apps` eyebrow in `layouts/index.html`.
- The `.eyebrow` is a small mono label with no width clamp, so the longer text wraps naturally within the hero column — no layout changes needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)