### PR TITLE
Reword copy so Anthias/Screenly read as examples, not the only options

### DIFF
--- a/hugo.toml
+++ b/hugo.toml
@@ -25,8 +25,8 @@ disableKinds = ["taxonomy", "term", "rss", "section"]
 
 [params]
   brand = "Screenly"
-  tagline = "Run free on Anthias, or managed with Screenly"
-  description = "Free, vendor-agnostic digital signage apps for any smart TV or signage player. Run them free and open-source with Anthias, or fully managed with Screenly."
+  tagline = "Free apps for any screen, on any platform"
+  description = "Free, vendor-agnostic digital signage apps for any smart TV or signage player. Every app is a plain URL, so it runs on whatever platform you already use — including free and open-source Anthias and fully managed Screenly."
   email = "hello@screenly.io"
   # Default image used for social sharing (Open Graph / Twitter cards).
   ogimage = "img/hero-3.jpg"

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -9,9 +9,10 @@
             </h1>
             <p class="mt-6 max-w-xl text-lg text-dim">
                 <strong class="font-semibold text-ink">Free</strong>, vendor-agnostic digital signage
-                apps. Pick one, copy the link, and run it on any smart TV or signage player:
-                free and open-source with <strong class="font-semibold text-ink">Anthias</strong>, or
-                fully managed with <strong class="font-semibold text-ink">Screenly</strong>.
+                apps. Pick one, copy the link, and run it on any smart TV or signage player &mdash;
+                whatever platform you already use, free and open-source
+                <strong class="font-semibold text-ink">Anthias</strong>, or fully managed
+                <strong class="font-semibold text-ink">Screenly</strong>.
             </p>
             <div class="mt-8 flex flex-wrap gap-3">
                 <a class="btn-primary" href="#apps">Browse apps {{ partial "icon.html" "arrow-right" }}</a>

--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -3,7 +3,7 @@
             <div class="text-center">
                 <p class="eyebrow">Run it your way</p>
                 <h2 class="mt-4 text-3xl sm:text-5xl">Free and open, or fully managed.</h2>
-                <p class="mx-auto mt-4 max-w-xl text-dim">Every one of these apps runs on both. Pick the platform that fits. There's no vendor lock-in.</p>
+                <p class="mx-auto mt-4 max-w-xl text-dim">Every app is a plain URL, so it runs on any platform &mdash; here are two great options. There's no vendor lock-in.</p>
             </div>
 
             <div class="mx-auto mt-10 grid max-w-3xl gap-5 sm:grid-cols-2">


### PR DESCRIPTION
## Summary
The site claims the apps are **vendor-agnostic**, but the surrounding copy framed Anthias and Screenly as the only two ways to run them, contradicting that narrative. This rewords three spots so those two are presented as options/examples, with "whatever platform you already use" leading:

- **Hero** (`layouts/index.html`): "…run it on any smart TV or signage player — whatever platform you already use, free and open-source **Anthias**, or fully managed **Screenly**."
- **Meta description + tagline** (`hugo.toml`): description now says every app is a plain URL that runs on whatever platform you already use; the unused `tagline` param had the same two-vendor framing and now reads "Free apps for any screen, on any platform".
- **"Run it your way" section** (`layouts/partials/footer.html`): "Every one of these apps runs on both" implied exactly two platforms; now "Every app is a plain URL, so it runs on any platform — here are two great options."

The Anthias/Screenly cards are unchanged — they remain the two promoted options, just no longer presented as the exhaustive set.

## Testing
- `hugo` builds cleanly; verified the new copy renders in `public/index.html`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)