### PR TITLE
Drop hero vendor names and remove em-dashes from user-facing copy

### DIFF
--- a/assets/js/config-world-clock.js
+++ b/assets/js/config-world-clock.js
@@ -115,12 +115,12 @@ export function initWorldClockConfig() {
   // link still works (the app falls back to its own default world view).
   const emptyHint = document.createElement('p');
   emptyHint.className = 'wc-empty';
-  emptyHint.textContent = 'No cities yet — the link will show a default world view.';
+  emptyHint.textContent = 'No cities yet. The link will show a default world view.';
 
   // Shown once the board is full, so disabling "Add city" doesn't look broken.
   const limitHint = document.createElement('p');
   limitHint.className = 'wc-empty';
-  limitHint.textContent = `That's the most that fits — up to ${MAX_CLOCKS} cities.`;
+  limitHint.textContent = `That's the most that fits: up to ${MAX_CLOCKS} cities.`;
 
   const rowCount = () => clocksEl.querySelectorAll('[data-wc-row]').length;
 

--- a/assets/js/lib/location-map.js
+++ b/assets/js/lib/location-map.js
@@ -32,7 +32,7 @@ const activeMounts = new Set();
 function showUnavailable(mount) {
   mount.classList.remove('is-touched');
   mount.classList.add('loc-map--unavailable');
-  mount.innerHTML = '<p class="loc-map__fallback">Map unavailable — the link still works without a location.</p>';
+  mount.innerHTML = '<p class="loc-map__fallback">Map unavailable. The link still works without a location.</p>';
 }
 
 // Google calls this global when the API key is rejected — e.g. this domain

--- a/content/world-clock/index.html
+++ b/content/world-clock/index.html
@@ -33,7 +33,7 @@ links:
         <div>
             <label class="eyebrow" for="wc-locale">Language &amp; region</label>
             <select id="wc-locale" class="field mt-2" data-wc-locale>
-                <option selected value="">English (UK) — default</option>
+                <option selected value="">English (UK) - default</option>
                 <option value="en-US">English (US)</option>
                 <option value="de-DE">German</option>
                 <option value="fr-FR">French</option>

--- a/hugo.toml
+++ b/hugo.toml
@@ -26,7 +26,7 @@ disableKinds = ["taxonomy", "term", "rss", "section"]
 [params]
   brand = "Screenly"
   tagline = "Free apps for any screen, on any platform"
-  description = "Free, vendor-agnostic digital signage apps for any smart TV or signage player. Every app is a plain URL, so it runs on whatever platform you already use — including free and open-source Anthias and fully managed Screenly."
+  description = "Free, vendor-agnostic digital signage apps for any smart TV or signage player. Every app is a plain URL, so it runs on whatever platform you already use, including free and open-source Anthias and fully managed Screenly."
   email = "hello@screenly.io"
   # Default image used for social sharing (Open Graph / Twitter cards).
   ogimage = "img/hero-3.jpg"

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -9,7 +9,7 @@
             </h1>
             <p class="mt-6 max-w-xl text-lg text-dim">
                 <strong class="font-semibold text-ink">Free</strong>, vendor-agnostic digital signage
-                apps. Pick one, copy the link, and run it on any smart TV or signage player &mdash;
+                apps. Pick one, copy the link, and run it on any smart TV or signage player,
                 whatever platform you already use.
             </p>
             <div class="mt-8 flex flex-wrap gap-3">

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -10,9 +10,7 @@
             <p class="mt-6 max-w-xl text-lg text-dim">
                 <strong class="font-semibold text-ink">Free</strong>, vendor-agnostic digital signage
                 apps. Pick one, copy the link, and run it on any smart TV or signage player &mdash;
-                whatever platform you already use, free and open-source
-                <strong class="font-semibold text-ink">Anthias</strong>, or fully managed
-                <strong class="font-semibold text-ink">Screenly</strong>.
+                whatever platform you already use.
             </p>
             <div class="mt-8 flex flex-wrap gap-3">
                 <a class="btn-primary" href="#apps">Browse apps {{ partial "icon.html" "arrow-right" }}</a>

--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -3,7 +3,7 @@
             <div class="text-center">
                 <p class="eyebrow">Run it your way</p>
                 <h2 class="mt-4 text-3xl sm:text-5xl">Free and open, or fully managed.</h2>
-                <p class="mx-auto mt-4 max-w-xl text-dim">Every app is a plain URL, so it runs on any platform &mdash; here are two great options. There's no vendor lock-in.</p>
+                <p class="mx-auto mt-4 max-w-xl text-dim">Every app is a plain URL, so it runs on any platform. Here are two great options. There's no vendor lock-in.</p>
             </div>
 
             <div class="mx-auto mt-10 grid max-w-3xl gap-5 sm:grid-cols-2">


### PR DESCRIPTION
## Summary
PR #36 was merged while two follow-up commits were still in flight, so they never landed on master. This PR carries exactly those two commits:

- **Drop vendor names from the hero sentence entirely** — the hero now ends at "…run it on any smart TV or signage player, whatever platform you already use."
- **Remove em-dashes from user-facing copy** — hero, "Run it your way" intro, `hugo.toml` meta description, the map-unavailable fallback, the World Clock hints, and the World Clock locale option label. Code comments and the map's coordinate-placeholder glyph are untouched.

Companion PRs already merged in the app repos: opening-hours#3, on-this-day#6, capital-quiz#6, product-hunt#3.

## Testing
- `hugo` builds cleanly; no em-dashes remain in rendered user-facing copy (the Opening Hours card text comes from its remote manifest, fixed in opening-hours#3).

🤖 Generated with [Claude Code](https://claude.com/claude-code)