### PR TITLE
Note player compatibility under Run it your way

### DIFF
--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -20,6 +20,14 @@
                     <a class="btn-primary mt-6 self-start" href="https://login.screenlyapp.com/sign-up?utm_source=signage-apps.com&amp;utm_medium=referral&amp;utm_campaign=app-store" target="_blank" rel="noopener">Start free trial {{ partial "icon.html" "arrow-right" }}</a>
                 </div>
             </div>
+
+            <p class="mx-auto mt-10 max-w-3xl text-center text-sm text-faint">
+                Already running something else? These apps work there too. Each one is a standard
+                web page, so it plays on BrightSign players, Samsung Tizen and LG webOS displays,
+                Android and Amazon Fire TV devices, and on digital signage platforms such as Yodeck,
+                ScreenCloud, OptiSigns, Xibo, Rise Vision and TelemetryTV. If your player can show
+                a URL, it can run these apps.
+            </p>
         </section>
 
         <footer class="border-t border-line">


### PR DESCRIPTION
## Summary
Adds a short, muted compatibility paragraph below the Anthias/Screenly cards in the "Run it your way" section. Since every app is a standard web page, it truthfully names the popular players and platforms they run on (BrightSign, Samsung Tizen, LG webOS, Android, Amazon Fire TV, Yodeck, ScreenCloud, OptiSigns, Xibo, Rise Vision, TelemetryTV), which also puts those vendor search terms on the homepage as crawlable prose.

Kept subtle by design: visible, small, `text-faint`, no hidden text or keyword lists, and it reinforces the vendor-agnostic message ("If your player can show a URL, it can run these apps.").

## Testing
- `hugo` builds cleanly and the paragraph renders on the homepage.
- `eslint` clean, `bun test` 21 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)